### PR TITLE
fix(helpdesk): translate dashboard labels + KPI widget titles

### DIFF
--- a/packages/helpdesk/src/translations/en.ts
+++ b/packages/helpdesk/src/translations/en.ts
@@ -154,4 +154,33 @@ export const en: TranslationData = {
       },
     },
   },
+  dashboards: {
+    agent_workbench_dashboard: {
+      label: 'Agent Workbench',
+      description: 'Your queue at a glance. Breaches, angry customers, AI-ready replies.',
+      widgets: {
+        my_open: { title: 'My Open Tickets' },
+        breaching_resolution: { title: 'SLA Breaching' },
+        angry: { title: 'Angry Customers' },
+        awaiting_triage: { title: 'Awaiting Triage' },
+        my_queue_table: { title: 'My Queue (Priority Sorted)' },
+        breaching_table: { title: 'SLA Breaches' },
+      },
+    },
+    manager_overview_dashboard: {
+      label: 'Support Manager Overview',
+      widgets: {
+        total_open: { title: 'Open Tickets' },
+        breaching_overview: { title: 'SLA Breaching' },
+        escalated: { title: 'Escalated' },
+        avg_csat: { title: 'Avg CSAT' },
+        tickets_by_status: { title: 'Tickets by Status' },
+        tickets_by_sentiment: { title: 'Sentiment Distribution' },
+        tickets_by_category: { title: 'AI Category Mix' },
+        tickets_by_channel: { title: 'Volume by Channel' },
+        recent_escalated: { title: 'Recently Escalated' },
+        resolutions_by_day: { title: 'Resolutions by Day (last 30 days)' },
+      },
+    },
+  },
 };

--- a/packages/helpdesk/src/translations/zh-CN.ts
+++ b/packages/helpdesk/src/translations/zh-CN.ts
@@ -154,4 +154,33 @@ export const zhCN: TranslationData = {
       },
     },
   },
+  dashboards: {
+    agent_workbench_dashboard: {
+      label: '客服工作台',
+      description: '一眼掌握你的队列：即将超时、不满客户、AI 拟好的回复。',
+      widgets: {
+        my_open: { title: '我的待处理工单' },
+        breaching_resolution: { title: 'SLA 即将超时' },
+        angry: { title: '不满客户' },
+        awaiting_triage: { title: '待分类' },
+        my_queue_table: { title: '我的队列（按优先级）' },
+        breaching_table: { title: 'SLA 超时工单' },
+      },
+    },
+    manager_overview_dashboard: {
+      label: '客服经理总览',
+      widgets: {
+        total_open: { title: '待处理工单' },
+        breaching_overview: { title: 'SLA 即将超时' },
+        escalated: { title: '已升级' },
+        avg_csat: { title: '平均满意度' },
+        tickets_by_status: { title: '按状态分布' },
+        tickets_by_sentiment: { title: '情绪分布' },
+        tickets_by_category: { title: 'AI 分类占比' },
+        tickets_by_channel: { title: '按渠道分布' },
+        recent_escalated: { title: '最近升级' },
+        resolutions_by_day: { title: '每日解决量（近 30 天）' },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Found during business-user testing (zh-CN)

The helpdesk dashboards rendered half-localized: object/field labels were Chinese, but dashboard titles, KPI widget titles, and dashboard nav entries stayed English.

**Root cause:** the translation bundles only populated `objects` and `apps`. `TranslationData` also supports a `dashboards` section (`dashboards.<name>.{label, widgets.<key>.title}`) — it was simply unused.

## Fix

Add `dashboards` translations for `agent_workbench_dashboard` and `manager_overview_dashboard` to both `en.ts` and `zh-CN.ts`.

## Verified end-to-end

Booted in the composed `all` environment and confirmed in the browser — the dashboard now renders fully Chinese:

| Before | After |
|---|---|
| Agent Workbench | 客服工作台 |
| My Open Tickets / SLA Breaching / Angry Customers / Awaiting Triage | 我的待处理工单 / SLA 即将超时 / 不满客户 / 待分类 |
| My Queue / SLA Breaches | 我的队列（按优先级）/ SLA 超时工单 |

`pnpm --filter @objectlab/helpdesk typecheck` passes.

> The same gap exists in the other 8 templates; this PR establishes the pattern. Rollout to the rest can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)