### PR TITLE
fix(i18n): complete zh-CN coverage across templates

### DIFF
--- a/packages/helpdesk/src/translations/en.ts
+++ b/packages/helpdesk/src/translations/en.ts
@@ -46,7 +46,10 @@ export const en: TranslationData = {
           label: 'AI Sentiment',
           options: { positive: 'Positive', neutral: 'Neutral', frustrated: 'Frustrated', angry: 'Angry' },
         },
-        ai_priority_suggestion: { label: 'AI Suggested Priority' },
+        ai_priority_suggestion: {
+          label: 'AI Suggested Priority',
+          options: { low: 'Low', normal: 'Normal', high: 'High', urgent: 'Urgent' },
+        },
         ai_language: { label: 'AI Detected Language' },
         ai_suggested_reply: { label: 'AI Suggested Reply' },
         ai_suggested_kb_ids: { label: 'AI Suggested KB Articles' },

--- a/packages/helpdesk/src/translations/zh-CN.ts
+++ b/packages/helpdesk/src/translations/zh-CN.ts
@@ -46,7 +46,10 @@ export const zhCN: TranslationData = {
           label: 'AI 情感',
           options: { positive: '积极', neutral: '中性', frustrated: '不满', angry: '愤怒' },
         },
-        ai_priority_suggestion: { label: 'AI 建议优先级' },
+        ai_priority_suggestion: {
+          label: 'AI 建议优先级',
+          options: { low: '低', normal: '普通', high: '高', urgent: '紧急' },
+        },
         ai_language: { label: 'AI 识别语言' },
         ai_suggested_reply: { label: 'AI 建议回复' },
         ai_suggested_kb_ids: { label: 'AI 推荐知识库' },

--- a/packages/procurement/src/translations/en.ts
+++ b/packages/procurement/src/translations/en.ts
@@ -55,7 +55,13 @@ export const en: TranslationData = {
         request_number: { label: 'PR Number' },
         requester: { label: 'Requester' },
         vendor: { label: 'Preferred Vendor' },
-        category: { label: 'Category' },
+        category: {
+          label: 'Category',
+          options: {
+            saas: 'Software / SaaS', hardware: 'Hardware', services: 'Professional Services',
+            marketing: 'Marketing', facilities: 'Facilities', other: 'Other',
+          },
+        },
         status: {
           label: 'Status',
           options: {
@@ -100,7 +106,10 @@ export const en: TranslationData = {
         owner: { label: 'Buyer' },
         total_amount: { label: 'Total Amount' },
         received_amount: { label: 'Received Amount' },
-        payment_terms: { label: 'Payment Terms' },
+        payment_terms: {
+          label: 'Payment Terms',
+          options: { net_15: 'Net 15', net_30: 'Net 30', net_45: 'Net 45', net_60: 'Net 60', upfront: 'Upfront' },
+        },
         is_fully_received: { label: 'Fully Received' },
         order_date: { label: 'Order Date' },
         expected_delivery: { label: 'Expected Delivery' },

--- a/packages/procurement/src/translations/zh-CN.ts
+++ b/packages/procurement/src/translations/zh-CN.ts
@@ -46,7 +46,13 @@ export const zhCN: TranslationData = {
         request_number: { label: '申请单号' },
         requester: { label: '申请人' },
         vendor: { label: '建议供应商' },
-        category: { label: '类别' },
+        category: {
+          label: '类别',
+          options: {
+            saas: '软件 / SaaS', hardware: '硬件', services: '专业服务',
+            marketing: '市场营销', facilities: '行政设施', other: '其他',
+          },
+        },
         status: {
           label: '状态',
           options: {
@@ -88,7 +94,10 @@ export const zhCN: TranslationData = {
         owner: { label: '采购员' },
         total_amount: { label: '订单金额' },
         received_amount: { label: '已收货金额' },
-        payment_terms: { label: '付款条款' },
+        payment_terms: {
+          label: '付款条款',
+          options: { net_15: '15 天', net_30: '30 天', net_45: '45 天', net_60: '60 天', upfront: '预付' },
+        },
         is_fully_received: { label: '已全部收货' },
         order_date: { label: '下单日期' },
         expected_delivery: { label: '预计到货' },

--- a/packages/project/src/translations/en.ts
+++ b/packages/project/src/translations/en.ts
@@ -3,99 +3,169 @@
 import type { TranslationData } from '@objectstack/spec/system';
 
 /**
- * English translations for Project Management template.
+ * English translations for the AI Project Management template.
  *
- * Shape follows `TranslationData`: field labels live under
- * `objects.<obj>.fields.<field>`, plural labels use `pluralLabel`, and the app
- * shell is translated under `apps.<app>`.
+ * Shape follows `TranslationData`: per-object label/pluralLabel/description,
+ * field labels + select options under `objects.<obj>.fields.<field>`, list-view
+ * labels under `objects.<obj>._views.<view>`, and the app shell under `apps.pm`.
+ * Field names mirror the `*.object.ts` definitions exactly.
  */
 export const en: TranslationData = {
   objects: {
     pm_project: {
       label: 'Project',
       pluralLabel: 'Projects',
+      description: 'A time-bound initiative with milestones, resources, and AI-powered risk prediction.',
       fields: {
-        code: { label: 'Project Code' },
         name: { label: 'Project Name' },
         description: { label: 'Description' },
-        status: { label: 'Status' },
-        priority: { label: 'Priority' },
-        health: { label: 'Health' },
+        status: {
+          label: 'Status',
+          options: {
+            planning: 'Planning', active: 'Active', at_risk: 'At Risk',
+            on_hold: 'On Hold', completed: 'Completed', cancelled: 'Cancelled',
+          },
+        },
+        priority: {
+          label: 'Priority',
+          options: { low: 'Low', medium: 'Medium', high: 'High', critical: 'Critical' },
+        },
+        project_type: {
+          label: 'Type',
+          options: { internal: 'Internal', client: 'Client', rnd: 'R&D', maintenance: 'Maintenance' },
+        },
         start_date: { label: 'Start Date' },
-        target_end_date: { label: 'Target End Date' },
+        planned_end_date: { label: 'Planned End Date' },
         actual_end_date: { label: 'Actual End Date' },
-        progress_percent: { label: 'Progress %' },
-        ai_completion_probability: { label: 'AI Completion Probability %' },
-        ai_delay_days: { label: 'AI Delay Days' },
+        ai_completion_probability: { label: 'AI Completion Probability' },
+        ai_delay_days: { label: 'AI Predicted Delay (Days)' },
         ai_risk_score: { label: 'AI Risk Score' },
-        ai_budget_variance_percent: { label: 'AI Budget Variance %' },
+        ai_budget_variance_forecast: { label: 'AI Budget Variance %' },
         ai_resource_bottleneck: { label: 'AI Resource Bottleneck' },
-        ai_recommended_action: { label: 'AI Recommended Action' },
+        ai_recommended_action: { label: 'AI Recommended Actions' },
+        ai_last_prediction_at: { label: 'Last AI Prediction' },
         planned_budget: { label: 'Planned Budget' },
         actual_cost: { label: 'Actual Cost' },
-        forecast_cost: { label: 'Forecast Cost' },
         project_manager: { label: 'Project Manager' },
         sponsor: { label: 'Sponsor' },
-        team_size: { label: 'Team Size' },
+        progress_percent: { label: 'Progress %' },
       },
+      _views: { all_projects: { label: 'All Projects' } },
     },
     pm_milestone: {
       label: 'Milestone',
       pluralLabel: 'Milestones',
+      description: 'A key delivery point or decision gate in a project timeline.',
       fields: {
         name: { label: 'Milestone Name' },
         description: { label: 'Description' },
         project: { label: 'Project' },
-        status: { label: 'Status' },
-        due_date: { label: 'Due Date' },
-        completed_at: { label: 'Completed At' },
-        is_critical_path: { label: 'Critical Path' },
+        status: {
+          label: 'Status',
+          options: {
+            not_started: 'Not Started', in_progress: 'In Progress',
+            completed: 'Completed', missed: 'Missed',
+          },
+        },
+        planned_date: { label: 'Planned Date' },
+        actual_date: { label: 'Actual Date' },
+        owner: { label: 'Owner' },
         deliverables: { label: 'Deliverables' },
       },
+      _views: { all_milestones: { label: 'All Milestones' } },
     },
     pm_risk: {
       label: 'Risk',
       pluralLabel: 'Risks',
+      description: 'A potential threat or uncertainty that could impact project delivery.',
       fields: {
-        risk_id: { label: 'Risk ID' },
-        name: { label: 'Risk Name' },
+        name: { label: 'Risk Title' },
         description: { label: 'Description' },
         project: { label: 'Project' },
-        category: { label: 'Category' },
-        status: { label: 'Status' },
-        impact: { label: 'Impact' },
-        likelihood: { label: 'Likelihood' },
-        priority: { label: 'Priority' },
+        status: {
+          label: 'Status',
+          options: {
+            identified: 'Identified', assessing: 'Assessing', mitigating: 'Mitigating',
+            monitoring: 'Monitoring', closed: 'Closed', realized: 'Realized',
+          },
+        },
+        category: {
+          label: 'Category',
+          options: {
+            technical: 'Technical', resource: 'Resource', schedule: 'Schedule',
+            budget: 'Budget', external: 'External', scope: 'Scope',
+          },
+        },
+        impact: {
+          label: 'Impact (Manual)',
+          options: { very_low: 'Very Low', low: 'Low', medium: 'Medium', high: 'High', very_high: 'Very High' },
+        },
+        likelihood: {
+          label: 'Likelihood (Manual)',
+          options: { very_low: 'Very Low', low: 'Low', medium: 'Medium', high: 'High', very_high: 'Very High' },
+        },
+        priority: { label: 'Risk Priority (Impact × Likelihood)' },
         ai_impact_score: { label: 'AI Impact Score' },
         ai_likelihood: { label: 'AI Likelihood' },
         ai_mitigation_suggestion: { label: 'AI Mitigation Suggestion' },
-        ai_similar_risks: { label: 'AI Similar Risks' },
-        response_strategy: { label: 'Response Strategy' },
-        response_plan: { label: 'Response Plan' },
-        response_owner: { label: 'Response Owner' },
-        response_cost: { label: 'Response Cost' },
+        ai_similar_risks: { label: 'AI Similar Past Risks' },
+        mitigation_plan: { label: 'Mitigation Plan' },
+        contingency_plan: { label: 'Contingency Plan' },
+        owner: { label: 'Risk Owner' },
       },
+      _views: { all_risks: { label: 'All Risks' } },
     },
     pm_issue: {
       label: 'Issue',
       pluralLabel: 'Issues',
+      description: 'A current problem that requires resolution.',
       fields: {
-        issue_number: { label: 'Issue #' },
-        name: { label: 'Issue Name' },
+        name: { label: 'Issue Title' },
         description: { label: 'Description' },
         project: { label: 'Project' },
-        type: { label: 'Type' },
-        status: { label: 'Status' },
-        priority: { label: 'Priority' },
-        reported_by: { label: 'Reported By' },
+        status: {
+          label: 'Status',
+          options: {
+            open: 'Open', in_progress: 'In Progress', blocked: 'Blocked',
+            resolved: 'Resolved', closed: 'Closed',
+          },
+        },
+        severity: {
+          label: 'Severity',
+          options: { low: 'Low', medium: 'Medium', high: 'High', critical: 'Critical' },
+        },
         assigned_to: { label: 'Assigned To' },
-        reported_at: { label: 'Reported At' },
-        resolved_at: { label: 'Resolved At' },
+        related_risk: { label: 'Related Risk' },
         resolution: { label: 'Resolution' },
       },
+      _views: { all_issues: { label: 'All Issues' } },
     },
-    pm_resource: { label: 'Resource', pluralLabel: 'Resources' },
-    pm_timesheet: { label: 'Timesheet', pluralLabel: 'Timesheets' },
+    pm_resource: {
+      label: 'Resource',
+      pluralLabel: 'Resources',
+      description: 'Team member or budget allocated to a project.',
+      fields: {
+        project: { label: 'Project' },
+        person: { label: 'Person' },
+        role: { label: 'Role' },
+        allocated_hours_per_week: { label: 'Allocated Hours/Week' },
+        start_date: { label: 'Allocation Start' },
+        end_date: { label: 'Allocation End' },
+      },
+    },
+    pm_timesheet: {
+      label: 'Timesheet Entry',
+      pluralLabel: 'Timesheet Entries',
+      description: 'Daily time tracking entry for a project.',
+      fields: {
+        project: { label: 'Project' },
+        person: { label: 'Person' },
+        work_date: { label: 'Work Date' },
+        hours: { label: 'Hours' },
+        description: { label: 'Description' },
+        billable: { label: 'Billable' },
+      },
+    },
   },
 
   apps: {

--- a/packages/project/src/translations/zh-CN.ts
+++ b/packages/project/src/translations/zh-CN.ts
@@ -3,98 +3,169 @@
 import type { TranslationData } from '@objectstack/spec/system';
 
 /**
- * 中文翻译 - 项目管理模板。
+ * 中文翻译 - AI 项目管理模板。
  *
- * 结构遵循 `TranslationData`：字段标签放在 `objects.<obj>.fields.<field>`，
- * 复数标签使用 `pluralLabel`，应用外壳在 `apps.<app>` 下翻译。
+ * 结构遵循 `TranslationData`：每个对象的 label/pluralLabel/description，
+ * 字段标签与下拉选项位于 `objects.<obj>.fields.<field>`，列表视图标签位于
+ * `objects.<obj>._views.<view>`，应用外壳位于 `apps.pm`。字段名与
+ * `*.object.ts` 定义完全一致。
  */
 export const zhCN: TranslationData = {
   objects: {
     pm_project: {
       label: '项目',
       pluralLabel: '项目',
+      description: '有明确周期的项目，包含里程碑、资源与 AI 风险预测。',
       fields: {
-        code: { label: '项目编号' },
         name: { label: '项目名称' },
         description: { label: '描述' },
-        status: { label: '状态' },
-        priority: { label: '优先级' },
-        health: { label: '健康度' },
+        status: {
+          label: '状态',
+          options: {
+            planning: '规划中', active: '进行中', at_risk: '存在风险',
+            on_hold: '已暂停', completed: '已完成', cancelled: '已取消',
+          },
+        },
+        priority: {
+          label: '优先级',
+          options: { low: '低', medium: '中', high: '高', critical: '紧急' },
+        },
+        project_type: {
+          label: '类型',
+          options: { internal: '内部', client: '客户', rnd: '研发', maintenance: '维护' },
+        },
         start_date: { label: '开始日期' },
-        target_end_date: { label: '目标结束日期' },
+        planned_end_date: { label: '计划结束日期' },
         actual_end_date: { label: '实际结束日期' },
-        progress_percent: { label: '进度 %' },
-        ai_completion_probability: { label: 'AI 完成概率 %' },
-        ai_delay_days: { label: 'AI 预测延期天数' },
+        ai_completion_probability: { label: 'AI 完成概率' },
+        ai_delay_days: { label: 'AI 预测延期（天）' },
         ai_risk_score: { label: 'AI 风险评分' },
-        ai_budget_variance_percent: { label: 'AI 预算偏差 %' },
+        ai_budget_variance_forecast: { label: 'AI 预算偏差 %' },
         ai_resource_bottleneck: { label: 'AI 资源瓶颈' },
         ai_recommended_action: { label: 'AI 推荐措施' },
+        ai_last_prediction_at: { label: '最近一次 AI 预测' },
         planned_budget: { label: '计划预算' },
         actual_cost: { label: '实际成本' },
-        forecast_cost: { label: '预测成本' },
         project_manager: { label: '项目经理' },
         sponsor: { label: '发起人' },
-        team_size: { label: '团队规模' },
+        progress_percent: { label: '进度 %' },
       },
+      _views: { all_projects: { label: '全部项目' } },
     },
     pm_milestone: {
       label: '里程碑',
       pluralLabel: '里程碑',
+      description: '项目时间线上的关键交付点或决策节点。',
       fields: {
         name: { label: '里程碑名称' },
         description: { label: '描述' },
         project: { label: '所属项目' },
-        status: { label: '状态' },
-        due_date: { label: '截止日期' },
-        completed_at: { label: '完成时间' },
-        is_critical_path: { label: '关键路径' },
+        status: {
+          label: '状态',
+          options: {
+            not_started: '未开始', in_progress: '进行中',
+            completed: '已完成', missed: '已错过',
+          },
+        },
+        planned_date: { label: '计划日期' },
+        actual_date: { label: '实际日期' },
+        owner: { label: '负责人' },
         deliverables: { label: '交付物' },
       },
+      _views: { all_milestones: { label: '全部里程碑' } },
     },
     pm_risk: {
       label: '风险',
       pluralLabel: '风险',
+      description: '可能影响项目交付的潜在威胁或不确定性。',
       fields: {
-        risk_id: { label: '风险 ID' },
         name: { label: '风险名称' },
         description: { label: '描述' },
         project: { label: '所属项目' },
-        category: { label: '类别' },
-        status: { label: '状态' },
-        impact: { label: '影响' },
-        likelihood: { label: '可能性' },
-        priority: { label: '优先级' },
+        status: {
+          label: '状态',
+          options: {
+            identified: '已识别', assessing: '评估中', mitigating: '缓解中',
+            monitoring: '监控中', closed: '已关闭', realized: '已发生',
+          },
+        },
+        category: {
+          label: '类别',
+          options: {
+            technical: '技术', resource: '资源', schedule: '进度',
+            budget: '预算', external: '外部', scope: '范围',
+          },
+        },
+        impact: {
+          label: '影响（人工）',
+          options: { very_low: '极低', low: '低', medium: '中', high: '高', very_high: '极高' },
+        },
+        likelihood: {
+          label: '可能性（人工）',
+          options: { very_low: '极低', low: '低', medium: '中', high: '高', very_high: '极高' },
+        },
+        priority: { label: '风险优先级（影响 × 可能性）' },
         ai_impact_score: { label: 'AI 影响评分' },
         ai_likelihood: { label: 'AI 可能性' },
         ai_mitigation_suggestion: { label: 'AI 缓解建议' },
-        ai_similar_risks: { label: 'AI 相似风险' },
-        response_strategy: { label: '应对策略' },
-        response_plan: { label: '应对计划' },
-        response_owner: { label: '负责人' },
-        response_cost: { label: '应对成本' },
+        ai_similar_risks: { label: 'AI 相似历史风险' },
+        mitigation_plan: { label: '缓解计划' },
+        contingency_plan: { label: '应急计划' },
+        owner: { label: '风险负责人' },
       },
+      _views: { all_risks: { label: '全部风险' } },
     },
     pm_issue: {
       label: '问题',
       pluralLabel: '问题',
+      description: '当前需要解决的问题。',
       fields: {
-        issue_number: { label: '问题编号' },
-        name: { label: '问题名称' },
+        name: { label: '问题标题' },
         description: { label: '描述' },
         project: { label: '所属项目' },
-        type: { label: '类型' },
-        status: { label: '状态' },
-        priority: { label: '优先级' },
-        reported_by: { label: '报告人' },
+        status: {
+          label: '状态',
+          options: {
+            open: '待处理', in_progress: '处理中', blocked: '受阻',
+            resolved: '已解决', closed: '已关闭',
+          },
+        },
+        severity: {
+          label: '严重程度',
+          options: { low: '低', medium: '中', high: '高', critical: '紧急' },
+        },
         assigned_to: { label: '分配给' },
-        reported_at: { label: '报告时间' },
-        resolved_at: { label: '解决时间' },
+        related_risk: { label: '关联风险' },
         resolution: { label: '解决方案' },
       },
+      _views: { all_issues: { label: '全部问题' } },
     },
-    pm_resource: { label: '资源', pluralLabel: '资源' },
-    pm_timesheet: { label: '工时', pluralLabel: '工时' },
+    pm_resource: {
+      label: '资源',
+      pluralLabel: '资源',
+      description: '分配给项目的团队成员或预算。',
+      fields: {
+        project: { label: '所属项目' },
+        person: { label: '成员' },
+        role: { label: '角色' },
+        allocated_hours_per_week: { label: '每周分配工时' },
+        start_date: { label: '分配开始' },
+        end_date: { label: '分配结束' },
+      },
+    },
+    pm_timesheet: {
+      label: '工时',
+      pluralLabel: '工时',
+      description: '项目的每日工时记录。',
+      fields: {
+        project: { label: '所属项目' },
+        person: { label: '成员' },
+        work_date: { label: '工作日期' },
+        hours: { label: '工时' },
+        description: { label: '描述' },
+        billable: { label: '可计费' },
+      },
+    },
   },
 
   apps: {


### PR DESCRIPTION
## Comprehensive i18n audit + fill

Wrote a coverage audit comparing each app's object metadata (field labels, select options, descriptions) against its zh-CN bundle, across all 9 templates. It found the last gaps and this PR closes them.

### Before
| app | fields | options | objDesc |
|---|---|---|---|
| helpdesk | 75/75 | 53/57 | 6/6 |
| procurement | 45/45 | 29/40 | 4/4 |
| project | 39/63 | 0/49 | 0/6 |

(the other 6 apps were already 100%)

### Fixes
- **helpdesk** — `helpdesk_ticket.ai_priority_suggestion` select options.
- **procurement** — `procurement_order.payment_terms` + `procurement_request.category` options.
- **project (pm)** — the bundle used **stale field names** that no longer matched the objects (so labels silently fell back to English). Rewritten against the actual `*.object.ts` field names with full field labels, all select options, object descriptions, and `_views` list labels, in both `en` and `zh-CN`.

### After — 100% across all 9 apps
fields, options, and object descriptions all fully covered. All packages typecheck + build; verified in the composed `all` environment (the pm app now renders fully Chinese with localized fields, options, and descriptions).

> Note: list-view *tab* labels (e.g. "Project Board") use `objects.<obj>._views` — added per schema, but this console build doesn't yet apply them to the tab strip. Correct data, pending renderer support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)