### PR TITLE
chore: bump 9 templates patch for @objectstack 7.7.0 republish

### DIFF
--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectlab/compliance",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "ObjectStack starter template: compliance posture & evidence management",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectlab/content",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "ObjectStack starter template: content marketing engine — editorial calendar, competitive signals, ROI by channel",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectlab/contracts",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "ObjectStack starter template: post-signature contract lifecycle management (CLM)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/expense/package.json
+++ b/packages/expense/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectlab/expense",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ObjectStack starter template: employee expense & reimbursement management",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/helpdesk/package.json
+++ b/packages/helpdesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectlab/helpdesk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "ObjectStack starter template: AI-first customer support helpdesk with native AI triage, suggested replies, and KB recall.",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/hr/package.json
+++ b/packages/hr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectlab/hr",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ObjectStack starter template: employee directory, org chart, time-off, and document tracking",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/procurement/package.json
+++ b/packages/procurement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectlab/procurement",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "ObjectStack starter template: source-to-pay procurement management",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectlab/project",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "description": "AI-powered project management template for ObjectStack",

--- a/packages/todo/package.json
+++ b/packages/todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectlab/todo",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "ObjectStack starter template: lightweight task management",
   "license": "Apache-2.0",
   "private": true,


### PR DESCRIPTION
The repo-wide @objectstack 7.4.1→7.7.0 upgrade (269d4ff) recompiled every template's metadata bundle (+ metadata-spec fixes), but the marketplace is **idempotent on version** — so the published versions still serve the **pre-7.7.0** bundles (last published 2026-05-30). Patch-bump the 9 already-listed templates so a republish actually ships the new bundles.

todo 0.1.2→0.1.3 · helpdesk 0.1.1→0.1.2 · hr 0.1.0→0.1.1 · project 0.1.0→0.1.1 · content 0.1.2→0.1.3 · procurement 0.1.2→0.1.3 · contracts 0.1.2→0.1.3 · expense 0.1.0→0.1.1 · compliance 0.1.2→0.1.3

(`all` aggregator stays 0.1.0 — not yet on the marketplace, publishes fresh.)

After merge: trigger `publish.yml` (workflow_dispatch) to publish to the marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)