### PR TITLE
ci: split marketplace publish into explicit staging + production workflows

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -1,0 +1,67 @@
+name: Publish to marketplace (production)
+
+# Publishes the template packages to the PRODUCTION marketplace
+# (https://cloud.objectos.ai). Target URL is hard-coded and the secret is
+# resolved from the `production` GitHub Environment.
+#
+# MANUAL ONLY — there is intentionally no `release`/`push` trigger. Production
+# is a deliberate promotion step: cut to staging first, verify, then dispatch
+# this. Add required-reviewers protection on the `production` environment in
+# repo settings so a prod publish needs an approval.
+on:
+  workflow_dispatch:
+    inputs:
+      templates:
+        description: 'Comma-separated package names to publish (empty = all)'
+        required: false
+        default: ''
+      dry_run:
+        description: 'Dry-run (print payloads, no HTTP)'
+        type: boolean
+        default: false
+
+concurrency:
+  group: publish-marketplace-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build + publish templates → production
+    runs-on: ubuntu-latest
+    # Scopes secrets to the `production` GitHub Environment and applies its
+    # protection rules (configure required reviewers + OS_CLOUD_API_KEY there).
+    environment: production
+    # Only run on the canonical repo, never on forks.
+    if: github.repository == 'objectstack-ai/templates'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all templates
+        run: pnpm -r build
+
+      - name: Resolve template filter
+        id: filter
+        run: echo "filter=${{ inputs.templates }}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to PRODUCTION marketplace
+        env:
+          OS_CLOUD_URL: https://cloud.objectos.ai
+          OS_CLOUD_API_KEY: ${{ secrets.OS_CLOUD_API_KEY }}
+          PUBLISH_TEMPLATES: ${{ steps.filter.outputs.filter }}
+          DRY_RUN: ${{ inputs.dry_run && '1' || '' }}
+        run: node scripts/publish-template.mjs

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -1,13 +1,13 @@
 name: Publish to marketplace (production)
 
 # Publishes the template packages to the PRODUCTION marketplace
-# (https://cloud.objectos.ai). Target URL is hard-coded and the secret is
-# resolved from the `production` GitHub Environment.
+# (https://cloud.objectos.ai). Target URL is hard-coded; the credential is the
+# production-only secret `OS_CLOUD_API_KEY_PRODUCTION` (set once at the ORG
+# level), fully separate from the staging key.
 #
 # MANUAL ONLY — there is intentionally no `release`/`push` trigger. Production
 # is a deliberate promotion step: cut to staging first, verify, then dispatch
-# this. Add required-reviewers protection on the `production` environment in
-# repo settings so a prod publish needs an approval.
+# this.
 on:
   workflow_dispatch:
     inputs:
@@ -31,9 +31,6 @@ jobs:
   publish:
     name: Build + publish templates → production
     runs-on: ubuntu-latest
-    # Scopes secrets to the `production` GitHub Environment and applies its
-    # protection rules (configure required reviewers + OS_CLOUD_API_KEY there).
-    environment: production
     # Only run on the canonical repo, never on forks.
     if: github.repository == 'objectstack-ai/templates'
     steps:
@@ -61,7 +58,10 @@ jobs:
       - name: Publish to PRODUCTION marketplace
         env:
           OS_CLOUD_URL: https://cloud.objectos.ai
-          OS_CLOUD_API_KEY: ${{ secrets.OS_CLOUD_API_KEY }}
+          # Distinct, production-only key — set once as an ORG-level secret,
+          # fully separate from the staging key. A staging dispatch can never
+          # carry the prod credential and vice-versa.
+          OS_CLOUD_API_KEY: ${{ secrets.OS_CLOUD_API_KEY_PRODUCTION }}
           PUBLISH_TEMPLATES: ${{ steps.filter.outputs.filter }}
           DRY_RUN: ${{ inputs.dry_run && '1' || '' }}
         run: node scripts/publish-template.mjs

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -3,7 +3,8 @@ name: Publish to marketplace (staging)
 # Publishes the template packages to the STAGING marketplace
 # (https://cloud.objectos.app). Target URL is hard-coded — there is no
 # ambiguous `vars.OS_CLOUD_URL`, so a dispatch can never accidentally hit
-# production. The secret is resolved from the `staging` GitHub Environment.
+# production. The credential is the staging-only secret
+# `OS_CLOUD_API_KEY_STAGING` (set once at the ORG level — no per-repo config).
 #
 # Triggers:
 #   1. Manual dispatch — normal releases, with optional template filter + dry-run.
@@ -34,10 +35,6 @@ jobs:
   publish:
     name: Build + publish templates → staging
     runs-on: ubuntu-latest
-    # Scopes secrets to the `staging` GitHub Environment (configure
-    # OS_CLOUD_API_KEY there; falls back to a repo-level secret of the same
-    # name if the environment has none).
-    environment: staging
     # Only run on the canonical repo, never on forks.
     if: github.repository == 'objectstack-ai/templates'
     steps:
@@ -77,7 +74,10 @@ jobs:
       - name: Publish to STAGING marketplace
         env:
           OS_CLOUD_URL: https://cloud.objectos.app
-          OS_CLOUD_API_KEY: ${{ secrets.OS_CLOUD_API_KEY }}
+          # Distinct, staging-only key — set once as an ORG-level secret so
+          # every repo's staging publish shares it (no per-repo / per-environment
+          # setup). Keeps staging credentials fully separate from production.
+          OS_CLOUD_API_KEY: ${{ secrets.OS_CLOUD_API_KEY_STAGING }}
           PUBLISH_TEMPLATES: ${{ steps.filter.outputs.filter }}
           DRY_RUN: ${{ inputs.dry_run && '1' || '' }}
         run: node scripts/publish-template.mjs

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,17 +1,14 @@
-name: Publish to marketplace
+name: Publish to marketplace (staging)
 
-# Trigger ONLY on explicit intent — never on plain push to main.
+# Publishes the template packages to the STAGING marketplace
+# (https://cloud.objectos.app). Target URL is hard-coded — there is no
+# ambiguous `vars.OS_CLOUD_URL`, so a dispatch can never accidentally hit
+# production. The secret is resolved from the `staging` GitHub Environment.
 #
-#   1. Manual dispatch — from Actions UI, with optional template filter +
-#      dry-run toggle. Use this for normal releases.
-#   2. GitHub Release published — tag like `todo-v0.2.0` or a multi-template
-#      release. The workflow filters via the tag name (if it looks like
-#      `<template>-v<semver>`) or just publishes whatever has a bumped
-#      version (the cloud side is idempotent — 409 on unchanged versions).
-#
-# Auto-publish on every push to main was intentionally removed: most pushes
-# touch unrelated code, versions don't bump in lockstep with commits, and a
-# bad publish lands on every user instantly.
+# Triggers:
+#   1. Manual dispatch — normal releases, with optional template filter + dry-run.
+#   2. GitHub Release published — auto-publish to staging (cloud is idempotent —
+#      409 on unchanged versions). Production is a separate, manual-only workflow.
 on:
   workflow_dispatch:
     inputs:
@@ -27,9 +24,7 @@ on:
     types: [published]
 
 concurrency:
-  group: publish-marketplace
-  # Don't cancel in-flight publishes — they're idempotent but a partial run
-  # is preferable to a cancelled one (you'd retry the next dispatch anyway).
+  group: publish-marketplace-staging
   cancel-in-progress: false
 
 permissions:
@@ -37,10 +32,13 @@ permissions:
 
 jobs:
   publish:
-    name: Build + publish templates
+    name: Build + publish templates → staging
     runs-on: ubuntu-latest
-    # Only run on the canonical repo, never on forks (where
-    # OS_CLOUD_API_KEY is unavailable). Adjust to your org slug.
+    # Scopes secrets to the `staging` GitHub Environment (configure
+    # OS_CLOUD_API_KEY there; falls back to a repo-level secret of the same
+    # name if the environment has none).
+    environment: staging
+    # Only run on the canonical repo, never on forks.
     if: github.repository == 'objectstack-ai/templates'
     steps:
       - uses: actions/checkout@v4
@@ -63,8 +61,8 @@ jobs:
       - name: Resolve template filter from release tag
         id: filter
         # If the tag looks like `<name>-v<semver>` (e.g. todo-v0.2.0), narrow
-        # the publish to just that template. Otherwise leave the filter
-        # empty so all templates are evaluated (each one is idempotent).
+        # the publish to just that template. Otherwise leave the filter empty
+        # so all templates are evaluated (each one is idempotent).
         run: |
           FILTER="${{ inputs.templates }}"
           if [ -z "$FILTER" ] && [ "${{ github.event_name }}" = "release" ]; then
@@ -76,9 +74,9 @@ jobs:
           fi
           echo "filter=$FILTER" >> "$GITHUB_OUTPUT"
 
-      - name: Publish to marketplace
+      - name: Publish to STAGING marketplace
         env:
-          OS_CLOUD_URL: ${{ vars.OS_CLOUD_URL }}
+          OS_CLOUD_URL: https://cloud.objectos.app
           OS_CLOUD_API_KEY: ${{ secrets.OS_CLOUD_API_KEY }}
           PUBLISH_TEMPLATES: ${{ steps.filter.outputs.filter }}
           DRY_RUN: ${{ inputs.dry_run && '1' || '' }}


### PR DESCRIPTION
Replaces the single `publish.yml` (ambiguous `vars.OS_CLOUD_URL`) with **two explicit, hard-coded-target** workflows using **distinct org-level secrets** — no GitHub Environments, no per-repo setup.

| Workflow | Target (hard-coded) | Secret | Triggers |
|---|---|---|---|
| `publish-staging.yml` | `https://cloud.objectos.app` | `OS_CLOUD_API_KEY_STAGING` | dispatch **+ release** (auto) |
| `publish-production.yml` | `https://cloud.objectos.ai` | `OS_CLOUD_API_KEY_PRODUCTION` | dispatch **only** (manual promote) |

Both reuse `scripts/publish-template.mjs`. Target URL + credential are fully separated per environment, so a staging dispatch can never carry the prod key or hit the prod cloud.

### Setup — one-time, ORG level (Settings → Secrets and variables → Actions)
Add two **organization** secrets (shared by all repos, no per-repo config):
- `OS_CLOUD_API_KEY_STAGING`
- `OS_CLOUD_API_KEY_PRODUCTION`

### Flow
Cut a release (or dispatch staging) → auto-publishes to **staging** → verify on cloud.objectos.app → dispatch **production** to promote.

Pairs with #19 (template version bumps for the 7.7.0 republish).