### PR TITLE
chore: upgrade @objectstack 7.7.0 → 8.0.1

### DIFF
--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -12,10 +12,10 @@
     "clean": "rm -rf .objectstack/marketplace-packages dist"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/compliance/src/data/index.ts
+++ b/packages/compliance/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Framework } from '../objects/compliance_framework.object';
 import { Control } from '../objects/compliance_control.object';
@@ -15,7 +15,7 @@ import { Assessment } from '../objects/compliance_assessment.object';
  *   • 5 assessments covering planned / in_progress / passed / failed / partial
  */
 
-const frameworks = defineDataset(Framework, {
+const frameworks = defineSeed(Framework, {
   mode: 'upsert',
   externalId: 'short_name',
   records: [
@@ -47,7 +47,7 @@ const frameworks = defineDataset(Framework, {
   ],
 });
 
-const controls = defineDataset(Control, {
+const controls = defineSeed(Control, {
   mode: 'upsert',
   externalId: 'code',
   records: [
@@ -120,7 +120,7 @@ const controls = defineDataset(Control, {
   ],
 });
 
-const evidence = defineDataset(Evidence, {
+const evidence = defineSeed(Evidence, {
   mode: 'upsert',
   externalId: 'title',
   records: [
@@ -186,7 +186,7 @@ const evidence = defineDataset(Evidence, {
   ],
 });
 
-const assessments = defineDataset(Assessment, {
+const assessments = defineSeed(Assessment, {
   mode: 'upsert',
   externalId: 'title',
   records: [

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/content/src/data/index.ts
+++ b/packages/content/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Competitor } from '../objects/content_competitor.object';
 import { Channel } from '../objects/content_channel.object';
@@ -11,6 +11,13 @@ import { Piece } from '../objects/content_piece.object';
 import { Publication } from '../objects/content_publication.object';
 import { Metric } from '../objects/content_metric.object';
 import { Cta } from '../objects/content_cta.object';
+
+// @objectstack 8.0.1: `defineSeed` types lookup/master_detail fields as
+// `string | null` and has no `multiple: true`-aware overload yet, so a
+// multi-value lookup seeded with an array fails typecheck. `multiRef` keeps
+// the array value (correct at runtime) while satisfying the field type.
+const multiRef = (ids: string[]): string => ids as unknown as string;
+
 
 /**
  * Seed data — realistic editorial workload covering the full template
@@ -31,7 +38,7 @@ import { Cta } from '../objects/content_cta.object';
  * changing the seed call sites.
  */
 
-const competitors = defineDataset(Competitor, {
+const competitors = defineSeed(Competitor, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -77,7 +84,7 @@ const competitors = defineDataset(Competitor, {
   ],
 });
 
-const channels = defineDataset(Channel, {
+const channels = defineSeed(Channel, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -124,7 +131,7 @@ const channels = defineDataset(Channel, {
   ],
 });
 
-const templates = defineDataset(ContentTemplate, {
+const templates = defineSeed(ContentTemplate, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -158,7 +165,7 @@ const templates = defineDataset(ContentTemplate, {
   ],
 });
 
-const signals = defineDataset(Signal, {
+const signals = defineSeed(Signal, {
   mode: 'upsert',
   externalId: 'headline',
   records: [
@@ -285,7 +292,7 @@ const signals = defineDataset(Signal, {
   ],
 });
 
-const topics = defineDataset(Topic, {
+const topics = defineSeed(Topic, {
   mode: 'upsert',
   externalId: 'title',
   records: [
@@ -377,7 +384,7 @@ const topics = defineDataset(Topic, {
   ],
 });
 
-const pieces = defineDataset(Piece, {
+const pieces = defineSeed(Piece, {
   mode: 'upsert',
   externalId: 'title',
   records: [
@@ -388,7 +395,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'backlog',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       summary: 'Side-by-side feature comparison with honest "they win here" sections.',
       tags: 'comparison, seo',
     },
@@ -399,7 +406,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'backlog',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       tags: 'ops, culture',
     },
     {
@@ -409,7 +416,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'backlog',
       format: 'listicle',
-      target_channels: ['Company Blog', 'Weekly Newsletter'],
+      target_channels: multiRef(['Company Blog', 'Weekly Newsletter']),
       tags: 'design, opinion',
     },
     {
@@ -419,7 +426,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'drafting',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       word_count_target: 1800,
       body_outline:
         '# The marketing metrics dashboard we actually use\n\n## What we track\n## What we stopped tracking\n## The dashboard itself\n## CTA',
@@ -433,7 +440,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'drafting',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       word_count_target: 600,
       body_outline:
         '# Picking the right region\n\n## A 30-second decision tree\n## One-line per region\n## What changes if you guess wrong\n## CTA',
@@ -446,7 +453,7 @@ const pieces = defineDataset(Piece, {
       template: 'Customer Story',
       status: 'drafting',
       format: 'case_study',
-      target_channels: ['Company Blog', 'LinkedIn Company Page'],
+      target_channels: multiRef(['Company Blog', 'LinkedIn Company Page']),
       word_count_target: 1200,
       tags: 'case-study, enterprise',
     },
@@ -457,7 +464,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'in_review',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       word_count_target: 1500,
       body_outline:
         '# How our SOC 2 program actually works\n\n## What SOC 2 actually requires\n## How we operationalised it\n## Where to find our report\n## CTA — book a security review',
@@ -472,7 +479,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'in_review',
       format: 'long_form',
-      target_channels: ['Company Blog', 'Weekly Newsletter'],
+      target_channels: multiRef(['Company Blog', 'Weekly Newsletter']),
       word_count_target: 2200,
       submitted_at: cel`daysAgo(1)`,
       summary: 'Real numbers, real runbook. Six-month bill, what we cut, what we kept.',
@@ -485,7 +492,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'approved',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       word_count_target: 500,
       submitted_at: cel`daysAgo(4)`,
       approved_at: cel`daysAgo(2)`,
@@ -498,7 +505,7 @@ const pieces = defineDataset(Piece, {
       template: 'Weekly Newsletter Issue',
       status: 'scheduled',
       format: 'newsletter',
-      target_channels: ['Weekly Newsletter'],
+      target_channels: multiRef(['Weekly Newsletter']),
       publish_at: cel`daysFromNow(2)`,
       submitted_at: cel`daysAgo(5)`,
       approved_at: cel`daysAgo(3)`,
@@ -512,7 +519,7 @@ const pieces = defineDataset(Piece, {
       template: 'Weekly Newsletter Issue',
       status: 'scheduled',
       format: 'newsletter',
-      target_channels: ['Weekly Newsletter'],
+      target_channels: multiRef(['Weekly Newsletter']),
       publish_at: cel`daysFromNow(9)`,
       submitted_at: cel`daysAgo(2)`,
       approved_at: cel`daysAgo(1)`,
@@ -526,7 +533,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'published',
       format: 'long_form',
-      target_channels: ['Company Blog', 'LinkedIn Company Page'],
+      target_channels: multiRef(['Company Blog', 'LinkedIn Company Page']),
       publish_at: cel`daysAgo(8)`,
       submitted_at: cel`daysAgo(14)`,
       approved_at: cel`daysAgo(10)`,
@@ -542,7 +549,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'published',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       publish_at: cel`daysAgo(22)`,
       submitted_at: cel`daysAgo(28)`,
       approved_at: cel`daysAgo(24)`,
@@ -557,7 +564,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'archived',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       publish_at: cel`daysAgo(160)`,
       submitted_at: cel`daysAgo(170)`,
       approved_at: cel`daysAgo(165)`,
@@ -570,7 +577,7 @@ const pieces = defineDataset(Piece, {
   ],
 });
 
-const publications = defineDataset(Publication, {
+const publications = defineSeed(Publication, {
   mode: 'upsert',
   externalId: 'public_url',
   records: [
@@ -624,7 +631,7 @@ const publications = defineDataset(Publication, {
 // 6 weekly snapshots per recent publication, 3 monthly snapshots for the
 // archived one. Each row is one period; the publication_rollup flow keeps
 // totals in sync (the publication.total_* above is a starting denormal).
-const metrics = defineDataset(Metric, {
+const metrics = defineSeed(Metric, {
   mode: 'upsert',
   externalId: 'note',
   records: [
@@ -682,7 +689,7 @@ const metrics = defineDataset(Metric, {
   ],
 });
 
-const ctas = defineDataset(Cta, {
+const ctas = defineSeed(Cta, {
   mode: 'upsert',
   externalId: 'variant',
   records: [

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/contracts/src/data/index.ts
+++ b/packages/contracts/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Party } from '../objects/contracts_party.object';
 import { Contract } from '../objects/contracts_contract.object';
@@ -22,7 +22,7 @@ import { Obligation } from '../objects/contracts_obligation.object';
  *   OBLIGATIONS 6
  */
 
-const parties = defineDataset(Party, {
+const parties = defineSeed(Party, {
   mode: 'upsert',
   externalId: 'legal_name',
   records: [
@@ -59,7 +59,7 @@ const parties = defineDataset(Party, {
   ],
 });
 
-const contracts = defineDataset(Contract, {
+const contracts = defineSeed(Contract, {
   mode: 'upsert',
   externalId: 'title',
   records: [
@@ -151,7 +151,7 @@ const contracts = defineDataset(Contract, {
   ],
 });
 
-const obligations = defineDataset(Obligation, {
+const obligations = defineSeed(Obligation, {
   mode: 'upsert',
   externalId: 'summary',
   records: [

--- a/packages/expense/package.json
+++ b/packages/expense/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/expense/src/data/index.ts
+++ b/packages/expense/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { ExpenseCategory } from '../objects/expense_category.object';
 import { ExpenseReport } from '../objects/expense_report.object';
@@ -16,7 +16,7 @@ import { ExpenseLine } from '../objects/expense_line.object';
  * relying on the line rollup hook (hooks fire on user edits, not seeds).
  */
 
-const categories = defineDataset(ExpenseCategory, {
+const categories = defineSeed(ExpenseCategory, {
   mode: 'upsert',
   externalId: 'code',
   records: [
@@ -53,7 +53,7 @@ const categories = defineDataset(ExpenseCategory, {
   ],
 });
 
-const reports = defineDataset(ExpenseReport, {
+const reports = defineSeed(ExpenseReport, {
   mode: 'upsert',
   externalId: 'report_number',
   records: [
@@ -126,7 +126,7 @@ const reports = defineDataset(ExpenseReport, {
   ],
 });
 
-const lines = defineDataset(ExpenseLine, {
+const lines = defineSeed(ExpenseLine, {
   mode: 'upsert',
   externalId: 'description',
   records: [

--- a/packages/helpdesk/package.json
+++ b/packages/helpdesk/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/helpdesk/src/data/index.ts
+++ b/packages/helpdesk/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Customer } from '../objects/helpdesk_customer.object';
 import { Team } from '../objects/helpdesk_team.object';
@@ -20,7 +20,7 @@ import { Message } from '../objects/helpdesk_message.object';
  *   • 8 messages (inbound, outbound, AI-drafted, internal note)
  */
 
-const teams = defineDataset(Team, {
+const teams = defineSeed(Team, {
   mode: 'upsert',
   externalId: 'code',
   records: [
@@ -48,7 +48,7 @@ const teams = defineDataset(Team, {
   ],
 });
 
-const slaPolicies = defineDataset(SLAPolicy, {
+const slaPolicies = defineSeed(SLAPolicy, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -109,7 +109,7 @@ const slaPolicies = defineDataset(SLAPolicy, {
   ],
 });
 
-const customers = defineDataset(Customer, {
+const customers = defineSeed(Customer, {
   mode: 'upsert',
   externalId: 'email',
   records: [
@@ -164,7 +164,7 @@ const customers = defineDataset(Customer, {
   ],
 });
 
-const kbArticles = defineDataset(KBArticle, {
+const kbArticles = defineSeed(KBArticle, {
   mode: 'upsert',
   externalId: 'slug',
   records: [
@@ -240,7 +240,7 @@ const kbArticles = defineDataset(KBArticle, {
   ],
 });
 
-const tickets = defineDataset(Ticket, {
+const tickets = defineSeed(Ticket, {
   mode: 'upsert',
   externalId: 'ticket_number',
   records: [
@@ -481,7 +481,7 @@ const tickets = defineDataset(Ticket, {
   ],
 });
 
-const messages = defineDataset(Message, {
+const messages = defineSeed(Message, {
   mode: 'upsert',
   externalId: 'name',
   records: [

--- a/packages/hr/package.json
+++ b/packages/hr/package.json
@@ -19,17 +19,17 @@
     "test:qa": "node ../../scripts/run-qa.mjs --url http://localhost:4009 --file qa/business-workflow.test.json"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/hr/src/data/index.ts
+++ b/packages/hr/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Department } from '../objects/hr_department.object';
 import { Employee } from '../objects/hr_employee.object';
@@ -16,7 +16,7 @@ import { EmployeeDocument } from '../objects/hr_document.object';
  *   • 5 documents: valid / expiring soon (within 30d) / expired
  */
 
-const departments = defineDataset(Department, {
+const departments = defineSeed(Department, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -32,7 +32,7 @@ const departments = defineDataset(Department, {
   ],
 });
 
-const employees = defineDataset(Employee, {
+const employees = defineSeed(Employee, {
   mode: 'upsert',
   externalId: 'work_email',
   records: [
@@ -134,7 +134,7 @@ const employees = defineDataset(Employee, {
   ],
 });
 
-const timeOff = defineDataset(TimeOffRequest, {
+const timeOff = defineSeed(TimeOffRequest, {
   mode: 'upsert',
   externalId: 'employee',
   records: [
@@ -189,7 +189,7 @@ const timeOff = defineDataset(TimeOffRequest, {
   ],
 });
 
-const documents = defineDataset(EmployeeDocument, {
+const documents = defineSeed(EmployeeDocument, {
   mode: 'upsert',
   externalId: 'name',
   records: [

--- a/packages/procurement/package.json
+++ b/packages/procurement/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/procurement/src/data/index.ts
+++ b/packages/procurement/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Vendor } from '../objects/procurement_vendor.object';
 import { PurchaseRequest } from '../objects/procurement_request.object';
@@ -15,7 +15,7 @@ import { GoodsReceipt } from '../objects/procurement_receipt.object';
  *   • 3 receipts demonstrating 3-way-match rollup
  */
 
-const vendors = defineDataset(Vendor, {
+const vendors = defineSeed(Vendor, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -63,7 +63,7 @@ const vendors = defineDataset(Vendor, {
   ],
 });
 
-const requests = defineDataset(PurchaseRequest, {
+const requests = defineSeed(PurchaseRequest, {
   mode: 'upsert',
   externalId: 'title',
   records: [
@@ -124,7 +124,7 @@ const requests = defineDataset(PurchaseRequest, {
   ],
 });
 
-const orders = defineDataset(PurchaseOrder, {
+const orders = defineSeed(PurchaseOrder, {
   mode: 'upsert',
   externalId: 'po_number',
   records: [
@@ -176,7 +176,7 @@ const orders = defineDataset(PurchaseOrder, {
   ],
 });
 
-const receipts = defineDataset(GoodsReceipt, {
+const receipts = defineSeed(GoodsReceipt, {
   mode: 'upsert',
   externalId: 'receipt_number',
   records: [

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -15,17 +15,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/project/src/data/issues.data.ts
+++ b/packages/project/src/data/issues.data.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { Issue } from '../objects/pm_issue.object.js';
 
 /**
@@ -8,14 +8,14 @@ import { Issue } from '../objects/pm_issue.object.js';
  * Current problems requiring resolution.
  * `project` references the parent project by its `name` externalId.
  */
-export const issues = defineDataset(Issue, {
+export const issues = defineSeed(Issue, {
   mode: 'upsert',
   externalId: 'name',
   records: [
     {
       name: 'Login page crashes on Android 12',
       description: 'App crashes when users try to log in on Android 12 devices.',
-      project: { name: 'Mobile App Redesign' },
+      project: 'Mobile App Redesign',
       status: 'in_progress',
       severity: 'high',
       assigned_to: null,
@@ -24,7 +24,7 @@ export const issues = defineDataset(Issue, {
     {
       name: 'API rate limiting too aggressive',
       description: 'Third-party API rate limits are blocking legitimate requests.',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       status: 'open',
       severity: 'medium',
       assigned_to: null,

--- a/packages/project/src/data/milestones.data.ts
+++ b/packages/project/src/data/milestones.data.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Milestone } from '../objects/pm_milestone.object.js';
 
@@ -9,14 +9,14 @@ import { Milestone } from '../objects/pm_milestone.object.js';
  * Mix of completed, upcoming, and at-risk milestones.
  * `project` references the parent project by its `name` externalId.
  */
-export const milestones = defineDataset(Milestone, {
+export const milestones = defineSeed(Milestone, {
   mode: 'upsert',
   externalId: 'name',
   records: [
     // Mobile App Redesign milestones
     {
       name: 'Design System Complete',
-      project: { name: 'Mobile App Redesign' },
+      project: 'Mobile App Redesign',
       status: 'completed',
       planned_date: cel`daysAgo(20)`,
       actual_date: cel`daysAgo(18)`,
@@ -24,7 +24,7 @@ export const milestones = defineDataset(Milestone, {
     },
     {
       name: 'Beta Release',
-      project: { name: 'Mobile App Redesign' },
+      project: 'Mobile App Redesign',
       status: 'in_progress',
       planned_date: cel`daysFromNow(30)`,
       deliverables: 'TestFlight beta with core features',
@@ -32,7 +32,7 @@ export const milestones = defineDataset(Milestone, {
     // ERP System Migration milestones
     {
       name: 'Data Migration Plan Approved',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       status: 'completed',
       planned_date: cel`daysAgo(60)`,
       actual_date: cel`daysAgo(55)`,
@@ -40,7 +40,7 @@ export const milestones = defineDataset(Milestone, {
     },
     {
       name: 'Phase 1 Data Cutover',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       status: 'in_progress',
       planned_date: cel`daysFromNow(10)`,
       deliverables: 'Core financial data migrated',
@@ -48,7 +48,7 @@ export const milestones = defineDataset(Milestone, {
     // AI Chatbot MVP milestones
     {
       name: 'LLM Vendor Selected',
-      project: { name: 'AI Chatbot MVP' },
+      project: 'AI Chatbot MVP',
       status: 'not_started',
       planned_date: cel`daysFromNow(20)`,
       deliverables: 'Signed vendor contract',

--- a/packages/project/src/data/projects.data.ts
+++ b/packages/project/src/data/projects.data.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Project } from '../objects/pm_project.object.js';
 
@@ -11,9 +11,9 @@ import { Project } from '../objects/pm_project.object.js';
  *   • AI Chatbot MVP - planning phase
  *
  * `name` is the externalId — it is also used by milestones / risks / issues /
- * resources to reference their parent project via `{ name: '…' }`.
+ * resources to reference their parent project via `'…'`.
  */
-export const projects = defineDataset(Project, {
+export const projects = defineSeed(Project, {
   mode: 'upsert',
   externalId: 'name',
   records: [

--- a/packages/project/src/data/resources.data.ts
+++ b/packages/project/src/data/resources.data.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Resource } from '../objects/pm_resource.object.js';
 
@@ -12,28 +12,28 @@ import { Resource } from '../objects/pm_resource.object.js';
  * The `role` text field carries the human-readable allocation label instead.
  * `project` references the parent project by its `name` externalId.
  */
-export const resources = defineDataset(Resource, {
+export const resources = defineSeed(Resource, {
   mode: 'upsert',
   externalId: 'role',
   records: [
     // Mobile App Redesign
     {
       role: 'Project Manager — Mobile App Redesign',
-      project: { name: 'Mobile App Redesign' },
+      project: 'Mobile App Redesign',
       allocated_hours_per_week: 20,
       start_date: cel`daysAgo(45)`,
       end_date: cel`daysFromNow(75)`,
     },
     {
       role: 'iOS Developer — Mobile App Redesign',
-      project: { name: 'Mobile App Redesign' },
+      project: 'Mobile App Redesign',
       allocated_hours_per_week: 40,
       start_date: cel`daysAgo(30)`,
       end_date: cel`daysFromNow(75)`,
     },
     {
       role: 'UI Designer — Mobile App Redesign',
-      project: { name: 'Mobile App Redesign' },
+      project: 'Mobile App Redesign',
       allocated_hours_per_week: 32,
       start_date: cel`daysAgo(45)`,
       end_date: cel`daysFromNow(60)`,
@@ -41,28 +41,28 @@ export const resources = defineDataset(Resource, {
     // ERP System Migration
     {
       role: 'Project Manager — ERP System Migration',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       allocated_hours_per_week: 40,
       start_date: cel`daysAgo(90)`,
       end_date: cel`daysFromNow(30)`,
     },
     {
       role: 'SAP Consultant — ERP System Migration',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       allocated_hours_per_week: 40,
       start_date: cel`daysAgo(75)`,
       end_date: cel`daysFromNow(45)`,
     },
     {
       role: 'Data Analyst — ERP System Migration',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       allocated_hours_per_week: 40,
       start_date: cel`daysAgo(60)`,
       end_date: cel`daysFromNow(30)`,
     },
     {
       role: 'QA Engineer — ERP System Migration',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       allocated_hours_per_week: 32,
       start_date: cel`daysAgo(30)`,
       end_date: cel`daysFromNow(30)`,
@@ -70,21 +70,21 @@ export const resources = defineDataset(Resource, {
     // AI Chatbot MVP
     {
       role: 'Project Manager — AI Chatbot MVP',
-      project: { name: 'AI Chatbot MVP' },
+      project: 'AI Chatbot MVP',
       allocated_hours_per_week: 16,
       start_date: cel`daysFromNow(7)`,
       end_date: cel`daysFromNow(97)`,
     },
     {
       role: 'ML Engineer — AI Chatbot MVP',
-      project: { name: 'AI Chatbot MVP' },
+      project: 'AI Chatbot MVP',
       allocated_hours_per_week: 40,
       start_date: cel`daysFromNow(7)`,
       end_date: cel`daysFromNow(97)`,
     },
     {
       role: 'Backend Developer — AI Chatbot MVP',
-      project: { name: 'AI Chatbot MVP' },
+      project: 'AI Chatbot MVP',
       allocated_hours_per_week: 32,
       start_date: cel`daysFromNow(14)`,
       end_date: cel`daysFromNow(97)`,

--- a/packages/project/src/data/risks.data.ts
+++ b/packages/project/src/data/risks.data.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { Risk } from '../objects/pm_risk.object.js';
 
 /**
@@ -8,14 +8,14 @@ import { Risk } from '../objects/pm_risk.object.js';
  * Includes AI-scored risks with mitigation plans.
  * `project` references the parent project by its `name` externalId.
  */
-export const risks = defineDataset(Risk, {
+export const risks = defineSeed(Risk, {
   mode: 'upsert',
   externalId: 'name',
   records: [
     {
       name: 'Backend team overallocation',
       description: 'Backend engineers are split across 3 concurrent projects, risking delays.',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       status: 'mitigating',
       category: 'resource',
       impact: 'high',
@@ -29,7 +29,7 @@ export const risks = defineDataset(Risk, {
     {
       name: 'LLM vendor pricing uncertainty',
       description: 'LLM API costs may exceed budget at scale.',
-      project: { name: 'AI Chatbot MVP' },
+      project: 'AI Chatbot MVP',
       status: 'identified',
       category: 'budget',
       impact: 'medium',
@@ -43,7 +43,7 @@ export const risks = defineDataset(Risk, {
     {
       name: 'Data integrity during migration',
       description: 'Risk of data loss or corruption during ERP cutover.',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       status: 'assessing',
       category: 'technical',
       impact: 'very_high',

--- a/packages/todo/package.json
+++ b/packages/todo/package.json
@@ -19,17 +19,17 @@
     "test:qa": "node ../../scripts/run-qa.mjs --url http://localhost:4002 --file qa/business-workflow.test.json"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/todo/src/data/index.ts
+++ b/packages/todo/src/data/index.ts
@@ -1,9 +1,16 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Task } from '../objects/todo_task.object';
 import { Label } from '../objects/todo_label.object';
+
+// @objectstack 8.0.1: `defineSeed` types lookup/master_detail fields as
+// `string | null` and has no `multiple: true`-aware overload yet, so a
+// multi-value lookup seeded with an array fails typecheck. `multiRef` keeps
+// the array value (correct at runtime) while satisfying the field type.
+const multiRef = (ids: string[]): string => ids as unknown as string;
+
 
 /**
  * Seed data — realistic, business-like task content covering the full
@@ -21,7 +28,7 @@ import { Label } from '../objects/todo_label.object';
  *               – 4 completed within the last 30 days
  */
 
-const labels = defineDataset(Label, {
+const labels = defineSeed(Label, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -36,7 +43,7 @@ const labels = defineDataset(Label, {
   ],
 });
 
-const tasks = defineDataset(Task, {
+const tasks = defineSeed(Task, {
   mode: 'upsert',
   externalId: 'subject',
   records: [
@@ -47,7 +54,7 @@ const tasks = defineDataset(Task, {
       estimate_hours: 4,
       due_date: cel`daysAgo(20)`,
       completed_at: cel`daysAgo(15)`,
-      labels: ['performance'],
+      labels: multiRef(['performance']),
     },
     {
       subject: 'Design new pricing page mockups',
@@ -55,7 +62,7 @@ const tasks = defineDataset(Task, {
       priority: 'high',
       estimate_hours: 12,
       due_date: cel`daysFromNow(7)`,
-      labels: ['feature', 'design'],
+      labels: multiRef(['feature', 'design']),
     },
     {
       subject: 'Fix mobile nav drawer animation',
@@ -63,7 +70,7 @@ const tasks = defineDataset(Task, {
       priority: 'urgent',
       estimate_hours: 3,
       due_date: cel`daysAgo(2)`, // overdue
-      labels: ['bug'],
+      labels: multiRef(['bug']),
     },
     {
       subject: 'Replace hero illustration with brand-refresh artwork',
@@ -71,7 +78,7 @@ const tasks = defineDataset(Task, {
       priority: 'normal',
       estimate_hours: 2,
       due_date: cel`daysFromNow(14)`,
-      labels: ['design'],
+      labels: multiRef(['design']),
     },
     {
       subject: 'Add cookie-consent banner (GDPR)',
@@ -80,7 +87,7 @@ const tasks = defineDataset(Task, {
       estimate_hours: 6,
       due_date: cel`daysAgo(10)`,
       completed_at: cel`daysAgo(8)`,
-      labels: ['security', 'feature'],
+      labels: multiRef(['security', 'feature']),
     },
     {
       subject: 'Implement offline-first task cache',
@@ -88,7 +95,7 @@ const tasks = defineDataset(Task, {
       priority: 'high',
       estimate_hours: 32,
       due_date: cel`daysFromNow(10)`,
-      labels: ['feature'],
+      labels: multiRef(['feature']),
     },
     {
       subject: 'Wire up push notifications',
@@ -96,7 +103,7 @@ const tasks = defineDataset(Task, {
       priority: 'normal',
       estimate_hours: 8,
       due_date: cel`daysFromNow(18)`,
-      labels: ['feature'],
+      labels: multiRef(['feature']),
     },
     {
       subject: 'Crash on cold-start when no network',
@@ -104,7 +111,7 @@ const tasks = defineDataset(Task, {
       priority: 'urgent',
       estimate_hours: 6,
       due_date: cel`daysAgo(1)`, // overdue
-      labels: ['bug'],
+      labels: multiRef(['bug']),
     },
     {
       subject: 'Reproduce biometric prompt bug',
@@ -112,7 +119,7 @@ const tasks = defineDataset(Task, {
       priority: 'high',
       estimate_hours: 4,
       due_date: cel`daysFromNow(3)`,
-      labels: ['bug', 'security'],
+      labels: multiRef(['bug', 'security']),
     },
     {
       subject: 'Localize onboarding flow (de / fr / ja)',
@@ -120,7 +127,7 @@ const tasks = defineDataset(Task, {
       priority: 'normal',
       estimate_hours: 16,
       due_date: cel`daysFromNow(28)`,
-      labels: ['feature'],
+      labels: multiRef(['feature']),
     },
     {
       subject: 'Drop legacy iOS support and bump min SDK',
@@ -128,7 +135,7 @@ const tasks = defineDataset(Task, {
       priority: 'low',
       estimate_hours: 2,
       due_date: cel`daysAgo(7)`,
-      labels: ['chore'],
+      labels: multiRef(['chore']),
     },
     {
       subject: 'Rotate signing keys for service-to-service JWTs',
@@ -136,7 +143,7 @@ const tasks = defineDataset(Task, {
       priority: 'urgent',
       estimate_hours: 4,
       due_date: cel`daysAgo(3)`, // overdue
-      labels: ['security'],
+      labels: multiRef(['security']),
     },
     {
       subject: 'Document rate-limit headers in developer portal',
@@ -144,7 +151,7 @@ const tasks = defineDataset(Task, {
       priority: 'normal',
       estimate_hours: 3,
       due_date: cel`daysFromNow(30)`,
-      labels: ['docs'],
+      labels: multiRef(['docs']),
     },
     {
       subject: 'Investigate p99 latency spike on /v1/search',
@@ -152,7 +159,7 @@ const tasks = defineDataset(Task, {
       priority: 'high',
       estimate_hours: 8,
       due_date: cel`daysFromNow(5)`,
-      labels: ['performance', 'blocked'],
+      labels: multiRef(['performance', 'blocked']),
     },
     {
       subject: 'Decommission v0 endpoints',
@@ -161,7 +168,7 @@ const tasks = defineDataset(Task, {
       estimate_hours: 6,
       due_date: cel`daysAgo(25)`,
       completed_at: cel`daysAgo(22)`,
-      labels: ['chore'],
+      labels: multiRef(['chore']),
     },
     {
       subject: 'Archive Q1 launch assets',
@@ -169,7 +176,7 @@ const tasks = defineDataset(Task, {
       priority: 'low',
       estimate_hours: 1,
       due_date: cel`daysFromNow(14)`,
-      labels: ['chore'],
+      labels: multiRef(['chore']),
     },
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,17 +18,17 @@ importers:
   packages/all:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -40,38 +40,38 @@ importers:
   packages/compliance:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -87,38 +87,38 @@ importers:
   packages/content:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -134,38 +134,38 @@ importers:
   packages/contracts:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -181,38 +181,38 @@ importers:
   packages/expense:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -228,38 +228,38 @@ importers:
   packages/helpdesk:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -275,38 +275,38 @@ importers:
   packages/hr:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -322,38 +322,38 @@ importers:
   packages/procurement:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -369,38 +369,38 @@ importers:
   packages/project:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -416,38 +416,38 @@ importers:
   packages/todo:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -775,35 +775,35 @@ packages:
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
-  '@objectstack/account@7.7.0':
-    resolution: {integrity: sha512-zbTAOeP22s6AyTph/FxyEZyU3RNHCJVq6Rb6Fr3R4wtLi0fWFgdLIL1DsODpwQKt3fjbaH49/8HfJDR7Ss20vw==}
+  '@objectstack/account@8.0.1':
+    resolution: {integrity: sha512-hio0SB54+dZJDVkpjU1OZ6Sft3Y1/6gBw0XLZmTqpKxRD6L5Upc/WJ9iL0o55hLvlFKB1d+PotaAtPFK9V6YWg==}
 
-  '@objectstack/cli@7.7.0':
-    resolution: {integrity: sha512-5A7j7z9JRyWl6OZUB5N3cmINI/8DtOvW3MtL9rTa/+4Hq2nYvC4GuKyXG641xTNQPJDraVVYcEhFHn+etry8rA==}
+  '@objectstack/cli@8.0.1':
+    resolution: {integrity: sha512-aMuZHCcLQ3ZB19utH8Rf5lMch9q1LfqMbpBwAawhl79P7QcDR+bX/xMprASM81m2kYhTT+La0dMadM6gkwgjnA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@objectstack/client@7.7.0':
-    resolution: {integrity: sha512-QxFIq99kuAXkkefzlnTM7g3btc4Rj/hzYbaf5PIqfitaoLJNswsa6LJuKoNaMQIdetUWsD3QfyM4iK5gdeJrFQ==}
+  '@objectstack/client@8.0.1':
+    resolution: {integrity: sha512-fLObUYXfa6XmoutgLK5SRthROKM16PTbMyOntiIoGI76zOHbsbZNa8FyDnSV7kEnjWERjBlEedjgT9201Pvnyg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/console@7.7.0':
-    resolution: {integrity: sha512-bG4FZe6mJSpenHAsBYqtQBCDcQcbTTRB66TMdoqVm1fM0546X07OD5cc85CUpt9fRDo7coTSjJpSv4XCKsHg7w==}
+  '@objectstack/console@8.0.1':
+    resolution: {integrity: sha512-d4I0hLRgJKV45MZanPWsCEyXxj7zzZMcjxdIBAc/g+CYWxS8i/dMgi5cuGnQxxPyopmElyadxoFav2tA3kScaA==}
 
-  '@objectstack/core@7.7.0':
-    resolution: {integrity: sha512-HwgkV2QInlT2q5QJQP11DM7/k/WSKvz2T1k78kQKFWB1zp2hhSNVy0C0f0pOPgNcLkShiIEPsFMPY5qV4zq1eA==}
+  '@objectstack/core@8.0.1':
+    resolution: {integrity: sha512-222khmv9KMBCI1dfjy2jknK9kpv/+RD9kcmNCrRApEzRQ5/TbE75UCM+T245yse61K7ez8CV0py/Yr5KJNj6FA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-memory@7.7.0':
-    resolution: {integrity: sha512-xUWXBIs6cTKlFzxSPLw3rpPF+VZ/b7huewWgrImaW27c7sZ39gWtiISlxI+4PdyJIlZFZq+V/rX0/XCn1UYpow==}
+  '@objectstack/driver-memory@8.0.1':
+    resolution: {integrity: sha512-rl3arNAOPotnlRi3PIkcN+597PBUXFdizfijjDOIMbi18KCCaMnFJY+rbk9ASfJv+kfN6L18S2EKSF6CnYoA6w==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-mongodb@7.7.0':
-    resolution: {integrity: sha512-8A31jNpRLahzWlassIi77y/6tQdO0k6ktU7qz2/T7cXnk1uWin/3sH4zvG5p/bb3m9VEhq3vF4AeQOpNnTEXXQ==}
+  '@objectstack/driver-mongodb@8.0.1':
+    resolution: {integrity: sha512-+qdeMt2gYT2NUO7WzoFYbZMvOLjy6n9N7Cs0QRGHFyNOAR9HRlGe/V97dpsmzDAiRDRXDsqdM3Z/shrEJykxZg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-sql@7.7.0':
-    resolution: {integrity: sha512-UPe0YgfYQyKe9wM9eugCmKFx3J3BDJxQLq/NLqsW+aoJeBtpQ4eG926uMm0MlZIq/XAVJtzKBJ6s5IHXSki53g==}
+  '@objectstack/driver-sql@8.0.1':
+    resolution: {integrity: sha512-2kT8VSqDQK1P1hQ2P84FE38fLrD75O9VxZZdLr20IfJI/kUn+klx0KLiu7dGCog7nDic3iSIxamsfxxh3fbSAA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       mysql2: ^3.0.0
@@ -820,15 +820,19 @@ packages:
       tedious:
         optional: true
 
-  '@objectstack/driver-sqlite-wasm@7.7.0':
-    resolution: {integrity: sha512-TOoXwt3mQnRfaBoNywgA5AEijJDb9a1WXxBiWHqFe3ZZ1vC91A9NkbtxWoNnewI2EeOQeNEwHGtm6UjHwYnWiQ==}
+  '@objectstack/driver-sqlite-wasm@8.0.1':
+    resolution: {integrity: sha512-C0bFYRRRyJJB5nJNCoreLWINf4qVEMaZivnioKFkex2Ycb3uwydFedyV7JwAertTjFXXoFaSI54KAXMV+4/Qfg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/formula@7.7.0':
-    resolution: {integrity: sha512-N0ZWFMYmEyz1wgY9FAcsAtYLOSmtvAOn0sxr1hU2SIpK6ZeSr5IZyLn7Pss+mpRLC3lPAiF5SsgutxCEixoy3A==}
+  '@objectstack/formula@8.0.1':
+    resolution: {integrity: sha512-e/CfchRGxnJW4JB1sDAaNKCAj0kbM83fSpzDmn3UMppG89aW9gSyMiB9TvaOnB35iOxsyhTeZ8R9E/rwEEfmfg==}
 
-  '@objectstack/metadata-core@7.7.0':
-    resolution: {integrity: sha512-W4a1Fm98KGPVsCuJtorlAZd7DkXSKh3Gqeb4+2/JdZFuQVQbJ3bJwtI3V3yxqUfGDBu7iwRzPemdgh08R8Mc+g==}
+  '@objectstack/mcp@8.0.1':
+    resolution: {integrity: sha512-KjJftJySVYvC0E4545iCDXgQLAo0FoxEQbXrXNpy1Yp5DtAYsEZESQodkqy0EJppxmtnXAqLD31k1fgjJUESjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@objectstack/metadata-core@8.0.1':
+    resolution: {integrity: sha512-VWrtvYm1pFoYXR2szmFXshNP6LSJ9sXiQPXtoOuKdZ6092Lt1wnSRrKR5RH5TpSaavXEdsidBffGI4NPp2Ej9A==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       vitest: ^4.0.0
@@ -836,83 +840,79 @@ packages:
       vitest:
         optional: true
 
-  '@objectstack/metadata-fs@7.7.0':
-    resolution: {integrity: sha512-AbwNa8aiaoy5uOIIEN3EbXaJT2V62dQ4m4fvpGLhXhPEJQo9YF/kb/AC0rc2tEDOgBKOi1RPoB3MVxC5Yy2IjQ==}
+  '@objectstack/metadata-fs@8.0.1':
+    resolution: {integrity: sha512-SdVofg5Bj21U5ZkCwSuHAAMjQqtto5SXZNnSrxzvJfh5Cq3AwG2d3RbWaJ+ev/dZeRJG5yuHiEhpdQJP+eOHGw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/metadata@7.7.0':
-    resolution: {integrity: sha512-mxhia9yLgZV/lzPaqnF4fVU1K2QSXHmYWxaJ+XcGiKgsVMlv9eHsK+pwLTxhyhYGV05YBeQzsPFMCbiHML8l3w==}
+  '@objectstack/metadata@8.0.1':
+    resolution: {integrity: sha512-wR6xSJbpSEDPRNMSBbLUyi+NtWsa0TVttgNJrZHqkb1+yLDGUc4K9NT0Et59nVqvVj5AjuC00Mk5uwzLxcxhPA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/objectql@7.7.0':
-    resolution: {integrity: sha512-k+Lx/iN+pKgYkHNy1hIMXu8ByNBaIUK22TW6HblkvFvBm6SlOiXLlV5SIF3AX7V+Dv3t8VPTTdWMWFXDkL2CZw==}
+  '@objectstack/objectql@8.0.1':
+    resolution: {integrity: sha512-c/n6OLYxC6rfipQjyVXy51u/N7wnWYp9hyllfv6kmujwK56yWKkY8iycAqboyCErgmPahuqW1LLdHjE1gmUiGw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/observability@7.7.0':
-    resolution: {integrity: sha512-WEb1YmQTqUhFlpomKi2Rxf4Eq4kYXrDQomENot86M9A0copywRldUl4A38SKbpNaH4bfjmcUbWuivEJGsUR9PA==}
+  '@objectstack/observability@8.0.1':
+    resolution: {integrity: sha512-XwUu5ZzcbJ+AwQ9Nyw17KfIq+WWsIBgAfqrTaTlqEB4tGHXUHEwGIgYcLS9eGDwS9H92ZhrTOY4kh9n7CdLhDg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/platform-objects@7.7.0':
-    resolution: {integrity: sha512-6nv6teqNVGNp+Tzd3YzLW+oBfK+bFUXGjU/A81qxqVB+HStTn4wqDULenhCNc6BMnw0QB9EEvOX4Ezqnv9xf/w==}
+  '@objectstack/platform-objects@8.0.1':
+    resolution: {integrity: sha512-3qOTeedtN78oyA4Oe/G21Lrf/H8nKa0oGsb8VoscS0nwdKmqRG4vlKplv998voEqro1HwIjvf5KZvQ1HBomVKw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-approvals@7.7.0':
-    resolution: {integrity: sha512-ktrxF+2Plohb+98cQB8WD2YjmtdCpP+ny9aaeqZqU6q6WZFhSj/1psFKfc6p4qWqnTYIhE6Ia3lf8ulZOyK4FA==}
+  '@objectstack/plugin-approvals@8.0.1':
+    resolution: {integrity: sha512-PCrqaTeEgQK+kDfEx4PUsaba9u9Ry/HFPrsx1xWkNS1sglfJG+LFqQEPHxUCDXIlap7hcj6gQtXJl42vVgZnPg==}
 
-  '@objectstack/plugin-audit@7.7.0':
-    resolution: {integrity: sha512-wigjWTNQz0lpK2mEg8ohcMBTJ25EGjOOMnk0BfsBRPRTnXtjPOd6Mhi+XY1IfVa6l20+9/oqJ3PbyBq93Qn2FQ==}
+  '@objectstack/plugin-audit@8.0.1':
+    resolution: {integrity: sha512-VqeC1xnLz1SPVo6+jOnPiWgJaiOPdXipyS6leS/wIVO6h+BcHR4e9XnQefYlB+ikVUeZwl6WM2iVHE48IatNuQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-auth@7.7.0':
-    resolution: {integrity: sha512-6dxO8XpIUuCD3cvu0tRQW5Vj6il72O6VHB1HZW6CG7rG9oALacUFNDlJcqSiZGtORgZbQDt8Np3d8foc6qhqBA==}
+  '@objectstack/plugin-auth@8.0.1':
+    resolution: {integrity: sha512-nLk3/lentF5qZ72X0c/fC5b8Ne/COg6dgwgUUscN8QQIR3EvHPsSWAeLOsrBVqb74v/ShxE81GkbxC0pK81fOQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-email@7.7.0':
-    resolution: {integrity: sha512-P3mN8T5CeM/pzaXRX1S3eaMIaY+ZcxgtcFtey2xo7i+++Kj+XpG+TNnBEAR0Zv46g5ITyX9rMp/nLD49ED6nsg==}
+  '@objectstack/plugin-email@8.0.1':
+    resolution: {integrity: sha512-psYJmJDp3LCYWCOk8b1ygVbjcYfYw+BVDeXAEl0LvkMPrPa/ugxAIcDINPSmZluTdL1BjionOSb/ohboHr/g+Q==}
 
-  '@objectstack/plugin-hono-server@7.7.0':
-    resolution: {integrity: sha512-pL14ZqDL4WS/MjJrc49PW2ygUsQozk6ccWV//9vgS7kwEbk2aPKWy58JD6lWIBduz0gWnDoT0IDH0TYMidbhMA==}
+  '@objectstack/plugin-hono-server@8.0.1':
+    resolution: {integrity: sha512-l2RKsunYIzxIU9emWxGVDOonoDDItiE/PDEA0qoBwUG2jUH4pkEahIaUKVgri9NZetKtp9ulKnHTHcDlzqpe7g==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-mcp-server@7.7.0':
-    resolution: {integrity: sha512-0lvHrFU/R5hZHd4fTbaVxTjmjtyKZ2tp/AF4MbgxZJAsU2Thf+cBnz3lHBbtpxGUdH2vsvTKqUuJoL95MK/3jQ==}
+  '@objectstack/plugin-org-scoping@8.0.1':
+    resolution: {integrity: sha512-PrrOzZbwW61AiPvDylSsSduR8Fi19l1pRjKk4e4VMSoJUiM9H+mdYxVtiANT+rpdEUxmjCl4tA1uv5WrGbkksA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-org-scoping@7.7.0':
-    resolution: {integrity: sha512-vxopncbwSI1jnmX1Hsde3tHKuL8hsCHbfZjXjILpAQPGdHmddE3CMwaE3yNFq07WmbIFf4o2kEaXphuECgN15A==}
+  '@objectstack/plugin-reports@8.0.1':
+    resolution: {integrity: sha512-500DjcpmmjtmvOUsrfwK+faGshBfoRAaXdfxzEjwHoFZfXTBX1Uc12YoTySoxQyuXoXE3Lw9OBARAyYiELss8Q==}
+
+  '@objectstack/plugin-security@8.0.1':
+    resolution: {integrity: sha512-NaEozXRvGH06UhFz2CVoKq8YoPc5OTTeoMk3IQ+kiUMz1w0Ky4dwTkXJzd9zW9aWL8cMQ9ezpC1oNQBVcaMo4Q==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-reports@7.7.0':
-    resolution: {integrity: sha512-0P33m1jmG3+NMmbIMuk2fJA8+qkNnwYDj3QFKmVvEVO5rApP7wfAUxL8H7qx10jAL9Fkr13I4GMggNfjbblcNg==}
+  '@objectstack/plugin-sharing@8.0.1':
+    resolution: {integrity: sha512-7vpjAG1uV0cgcxhnEB05WyjGhwlYT7ezufo+83ya9kxJdORnyo8wPHsQ5bnuntOdz0aTtn5WTvS4nQVlZoxkaw==}
 
-  '@objectstack/plugin-security@7.7.0':
-    resolution: {integrity: sha512-NnnsFrbxFp8xAECkKjIkUzKHsrjWWIVWTJrn+xAYzk17ToTjU47qBDdfRZdv+36B7WPLt4jwAz2sVg3IzPdpzg==}
+  '@objectstack/plugin-trigger-record-change@8.0.1':
+    resolution: {integrity: sha512-dvedWALQ78q6cqfwVskZmwcml4f7FsifgqYosNkQWVDW4yE+6em4Gro3ert8XmMBQomFl85SttHf6VdiOiZoYg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-sharing@7.7.0':
-    resolution: {integrity: sha512-KNmaWZ/q9c4gFGSRqFAX7A5pdt5jTnc9+LdvJy/ONndCeIJI8dZXX3zlvZlifkqJt2zbRwO1uQ8e+72y7UZKWA==}
-
-  '@objectstack/plugin-trigger-record-change@7.7.0':
-    resolution: {integrity: sha512-Ds8W3z+cLFpKeWXA4jvB8y3KV8yiSRP8K2L22SPNpAanjIDn2LkwblTQDEZwl1kRXAYa3SQ3kWWCeFDqN2WoHQ==}
+  '@objectstack/plugin-trigger-schedule@8.0.1':
+    resolution: {integrity: sha512-xMiICt1+v/afoTZ8hy/e1Wyi2NEYFQkLxtqxMC72AtIYT6caHJFJLAvzn15Y1nQeMs4tQAJh8t23n1+6hZ8cxQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-trigger-schedule@7.7.0':
-    resolution: {integrity: sha512-z+Rrty6FVn+bOSbqW9Es1hEPTr8MzG1yBb6dRyaXqRUaitIurmsVAOfX+IYBSx72pvBG3lmXkzeW7J4nOuv8gQ==}
+  '@objectstack/plugin-webhooks@8.0.1':
+    resolution: {integrity: sha512-UMzvj2UDm2wJcKQ4yCdOnWxQj/rL/rni90ZkDFwJaVqdstRWmNE/gVUssPvPKTNuA2HxC4+rQdIUfXRQMZvmtQ==}
+
+  '@objectstack/rest@8.0.1':
+    resolution: {integrity: sha512-YA05taXQs3Rzz/DHlF5XBb9BKcmevDHhSA+YmXX8gTIwsuxWQgYG1YyrnWAPBNByyTwCHXqaT/bcBOE0IZ2Wlg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-webhooks@7.7.0':
-    resolution: {integrity: sha512-DZCN5PgX6hOb0TCjYKBc4IfrX75/7cBFZG/xXEwxDX0el5pIvkR7IZK27LJwtD8ZXd6DpvXu4lS/qBUAwi8bpw==}
-
-  '@objectstack/rest@7.7.0':
-    resolution: {integrity: sha512-wN5vmXhyPRavDb4LfxUFMU7Lgh1LPuk6rekLnNg7Eds5eVsVKio2eAtxzIErH8BOntlDKEvsVJv73cSFnapZ6g==}
+  '@objectstack/runtime@8.0.1':
+    resolution: {integrity: sha512-fY5DtKCexgM5AjQnd363wamvLPS88SrDeK7mF84YDoVksD7JmCyeoMzeLQAGm3kOj3dX2F5uEE39m64pUeL+4w==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/runtime@7.7.0':
-    resolution: {integrity: sha512-vzcwZoBC+EyXu2n9IU8sAnGrvtjlW9AuhUWZ9yjLz20Og1AZ8oVXv2aPJGwZXkOehz/ct3b28qn/eY/SEbWmwA==}
-    engines: {node: '>=18.0.0'}
-
-  '@objectstack/service-ai@7.7.0':
-    resolution: {integrity: sha512-i44xxXNx9LE7SfyUS3UOnlpyLSj2yKQUwyOY2wnNwNErjapfkQ0SmlGUNTnhFTRDlM0we33lHovdJJb1QnLNuA==}
+  '@objectstack/service-ai@8.0.1':
+    resolution: {integrity: sha512-i1dj3BV8O/C8ENFDmEzEgIQ7iVt7WPetmRUz5JRYFM+ubeErVwaJAm1JAn/HJ6SRQl7i7fO+fgjWSLvlUr6THA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@ai-sdk/anthropic': ^3.0.0
@@ -929,58 +929,58 @@ packages:
       '@ai-sdk/openai':
         optional: true
 
-  '@objectstack/service-analytics@7.7.0':
-    resolution: {integrity: sha512-8vH7T7BuVyRp7QPc9thMlEYfdIMIQpasH5NzBVR079vOOcFoZfHzIKvQONUgEBB3bCM6Zl6+p86kMdEWAfL07Q==}
+  '@objectstack/service-analytics@8.0.1':
+    resolution: {integrity: sha512-3DWT/kmeM/U4wOzrk2yO1vyrlkij8KLhQIuhbDCth+Xwwj94U4YaPs8JbdmfsSEfec+D5YGnfGaagdk0Q87ejw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-automation@7.7.0':
-    resolution: {integrity: sha512-MdW1o2A40UUzZTCG5+XVbTbY7jCViNRPo5lgSYzIVMbfklhQjEYQNIHU2WlP1HgbOlf78NyVUl+lpyscX+tSzg==}
+  '@objectstack/service-automation@8.0.1':
+    resolution: {integrity: sha512-eiZQH/FGh5Mj1I5EYtn8FGRibWTusM9+SbiE90F02BJ4CSC56PlJ5lXJofyktme+EQf+yQsS/Ck30fAkMZpXYg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-cache@7.7.0':
-    resolution: {integrity: sha512-0TBJ5yCGBpsWCOOnmJbWoefSJsXWicl4YVxKouC4bolbYJLMWlCH7D3ZoI2f4zQvb/uguIx2p/+rrSsfT6SR/Q==}
+  '@objectstack/service-cache@8.0.1':
+    resolution: {integrity: sha512-ZZzseZzvflsa2NyC1JUvGUVbq/BYBdQpop3jqZ4W7lqquueiHkN3ffbHGnSf7HJL++/fkwMKKZiDahSecCg7kA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-cluster@7.7.0':
-    resolution: {integrity: sha512-H9RBrgmnMVHZYZI9KKAQdChEAlTIpZh7IiQN1LydouQibZw1k7FveuMyzwhV384gq/VueE03jEgQVZddiAeqDw==}
+  '@objectstack/service-cluster@8.0.1':
+    resolution: {integrity: sha512-FR8cHaM/45Ez9VICsp8B1KtwBNlyotqmuazgnT7vJ7FySMRyGKjcWw03Ua8pgYQFYwSpKOl73esgljBCeOuAXw==}
 
-  '@objectstack/service-datasource@7.7.0':
-    resolution: {integrity: sha512-oenatd7hSIXH3Zgd/AoZN/916pWjsZkHSdrsMOWCxqEUmueKXPorctn1Y62liXN3zI91bHJBIP4Wkc9BdoA3LA==}
+  '@objectstack/service-datasource@8.0.1':
+    resolution: {integrity: sha512-kKR0m3YlUw9/Kk4YfjLWqixKYLg5an0G/yNIJxBSrTSAz/9c9XNzfyon5QWvhJg5EPoY/01VKvlGxbcqh1guVA==}
 
-  '@objectstack/service-feed@7.7.0':
-    resolution: {integrity: sha512-G9TEwyTscCDY7qS/3HBEXpFqLxEdri4zIwk6gLdpLw7hQsWEMmZBn8CzAo2IEsGukFi/z9MTkXvF3bwT7kx/pw==}
+  '@objectstack/service-feed@8.0.1':
+    resolution: {integrity: sha512-nGIxnV5qXpp9dL7njuTXq/TA2dAZMFddAcRHhdH9q8qyVdO2DcOi8n4MSaaqdALUnNbwTCLImEuhVTxF+Yo15A==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-i18n@7.7.0':
-    resolution: {integrity: sha512-JYa1EEivpkPOCG6ReKDFZeKkzJkgoXayKHnmcjDBtJSRMVWvgdftq4WoKsWiFsTcG4mkkFktzTrmCq22lZEY5w==}
+  '@objectstack/service-i18n@8.0.1':
+    resolution: {integrity: sha512-h1YjPxHURiLyIc3Mf7dOJ1pgVtnkHxh3ppWuW650pXYo4F4Ys5gbsNNxUD1fuJhGQiQaycBPfADw/0BdK+wv+Q==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-job@7.7.0':
-    resolution: {integrity: sha512-tErPzkcawnpzSubp2PB3mQN8MeA3CV5nGIw8Yy/vLl2cQBBkfI9Gq5rQTBMwfEFUhUuy+6QV1ys04M2GutT88A==}
+  '@objectstack/service-job@8.0.1':
+    resolution: {integrity: sha512-KlTBzR/RL8yIMp4qxpkaoZYYsktAedq1GbgNxTDCWL9wbRGL7S0GNvvG1/dPbg71jgDNIzYUdFjfWCwj5upHkg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-messaging@7.7.0':
-    resolution: {integrity: sha512-Zufrs7SdXPQ0DlA8Mhfr3e+T8isy0w4jk4wdyWNoucqCRTXn0hLoKYp5ovfjpcjoZlCiG7pF8aUJ0Ldpr76uMA==}
+  '@objectstack/service-messaging@8.0.1':
+    resolution: {integrity: sha512-k3q4RyxOEy3U0NxYfVCGcQsi2cNXsvqjNrvUMrMh9Fuew6WHOeuUJ3ftChfOR8EzYHdT/OH/8VYzQjxmKVxNwQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-package@7.7.0':
-    resolution: {integrity: sha512-eENxVcH3pGmLFQQgqPYY6DWwwwX1O6BZZOhzlMlSMhc4ka4lUE0W5JOkrXjagIJckKf3ul6f5DguVLT5wn9N8g==}
+  '@objectstack/service-package@8.0.1':
+    resolution: {integrity: sha512-hTxON2MnrFAHDRNKXYudG0qoSOYbTvpYG7qeo19NnT+lWvvMGcL/9v02SQzjIWZEaV+wsubF0bArdaD2qI5vyQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-queue@7.7.0':
-    resolution: {integrity: sha512-Ekf3IX/t0LUz690mMXQufnHazoxeBrqSNkuRvWWtRn3rzhBg1Uxjl9P/CJiP2JwIR4KotmYScJP9mGftw1TDZg==}
+  '@objectstack/service-queue@8.0.1':
+    resolution: {integrity: sha512-WoOvd+3IQODws99OIwIXQ4armhW0N7JiRQG8Vip6y6s+OFQkZgB5/IG7xtxPHQAAgfmdSDKsNvteeZd2MTK5kg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-realtime@7.7.0':
-    resolution: {integrity: sha512-q/wrSVB5NhSZSIToE7TvFqkHPUtwfMSEHS0E475UButbRLRu/EzgfQ7CPFO/APv9zetjQJmF/hNaKrrcQZmkog==}
+  '@objectstack/service-realtime@8.0.1':
+    resolution: {integrity: sha512-btZGq/ap0Gzl7Ftd886XgMbLclqTbIuAi4B1g1mpAQja8fHQahRiYo/5UW6UXiWlSf4mKOidRrWpmQpjACVR4A==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-settings@7.7.0':
-    resolution: {integrity: sha512-9F21JIjEjrK0RbHn3QFSaI9dZbR9fE678HjJHm287d4ARPog0aLT1LoSuH7x3eZLGzEWwMt4xZHoGImaj0MYYg==}
+  '@objectstack/service-settings@8.0.1':
+    resolution: {integrity: sha512-/Kco/IfvdeMzioPP7UrkqTTVHatrtoHDr2R0VTDvC7jMV2HZORqdFgBWGVmLdY9xUF59I1OP/FxgwtfoT6ixAg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-storage@7.7.0':
-    resolution: {integrity: sha512-KCNbp4DmeudFb/eTbnqxmvopfzPwYatRe0pOZqDVnwXjPU3C/UNLu3Si6XNu9f7T8tm6gJztp9ofFCfGYpctPw==}
+  '@objectstack/service-storage@8.0.1':
+    resolution: {integrity: sha512-SOnvpditPPf4AdaqKCXHPxqQXGw0k3UD67RDTHouk2N+JKoa+Sx0osS0TzhkhrVwha4Kxdvu0M+tyWh0DAGbcA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@aws-sdk/client-s3': ^3.0.0
@@ -991,8 +991,8 @@ packages:
       '@aws-sdk/s3-request-presigner':
         optional: true
 
-  '@objectstack/spec@7.7.0':
-    resolution: {integrity: sha512-p9GxtbD8oJFkf9tjNlaOZmBxufskk683IhBL0My8NK0EOH/xG1xbbeAWctpHHIdK91hz9EkZLthtJVbnBNaMPw==}
+  '@objectstack/spec@8.0.1':
+    resolution: {integrity: sha512-ZTHxY0TJIGDGNNd+i5Jzl8KQEA4wxgm46WTICrrYEybdsUnSkuOEKSW3lH0IBB8vI9Dx8/yUtKw77Di9NDfkAw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       ai: ^6.0.0
@@ -1000,8 +1000,8 @@ packages:
       ai:
         optional: true
 
-  '@objectstack/types@7.7.0':
-    resolution: {integrity: sha512-msQcyAmD1cFB4KQ3EH9brnoqBIXMTwwmSAagtbJqCBj7bFLKmtAXdjWHp+6FQFG5lHDBwldA0aRO5DEvdzOZaA==}
+  '@objectstack/types@8.0.1':
+    resolution: {integrity: sha512-1oA7/z2k9UkdopRCmEHLVj5bpQJxBZt3qBI8TxN81LhDzTBibI4Bl5qBJiUPc7ClNQuCQHrUjRD/NTadSkq7Dw==}
     engines: {node: '>=18.0.0'}
 
   '@oclif/core@4.11.4':
@@ -2262,53 +2262,53 @@ snapshots:
 
   '@noble/hashes@2.2.0': {}
 
-  '@objectstack/account@7.7.0': {}
+  '@objectstack/account@8.0.1': {}
 
-  '@objectstack/cli@7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@objectstack/cli@8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@ai-sdk/gateway': 3.0.122(zod@4.4.3)
-      '@objectstack/account': 7.7.0
-      '@objectstack/client': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/console': 7.7.0
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-memory': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-mongodb': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-sql': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-sqlite-wasm': 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
-      '@objectstack/formula': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/objectql': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/observability': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-approvals': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-audit': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-auth': 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@objectstack/plugin-email': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-hono-server': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-mcp-server': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-org-scoping': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-reports': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-security': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-sharing': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-trigger-record-change': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-trigger-schedule': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-webhooks': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/rest': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/runtime': 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@objectstack/service-ai': 7.7.0(@ai-sdk/gateway@3.0.122(zod@4.4.3))
-      '@objectstack/service-analytics': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-automation': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-cache': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-datasource': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-feed': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-job': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-messaging': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-package': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-queue': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-realtime': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-settings': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-storage': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/account': 8.0.1
+      '@objectstack/client': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/console': 8.0.1
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-memory': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-mongodb': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-sql': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-sqlite-wasm': 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+      '@objectstack/formula': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/mcp': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/objectql': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-approvals': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-audit': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-auth': 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/plugin-email': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-hono-server': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-org-scoping': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-reports': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-security': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-sharing': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-trigger-record-change': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-trigger-schedule': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-webhooks': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/rest': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/runtime': 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/service-ai': 8.0.1(@ai-sdk/gateway@3.0.122(zod@4.4.3))
+      '@objectstack/service-analytics': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-automation': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-cache': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-datasource': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-feed': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-job': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-messaging': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-package': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-queue': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-realtime': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-settings': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-storage': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       '@oclif/core': 4.11.4
       bundle-require: 5.1.0(esbuild@0.28.0)
       chalk: 5.6.2
@@ -2368,34 +2368,34 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/client@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/client@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/console@7.7.0': {}
+  '@objectstack/console@8.0.1': {}
 
-  '@objectstack/core@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/core@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-memory@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/driver-memory@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       mingo: 7.2.1
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-mongodb@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/driver-mongodb@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       mongodb: 7.2.0
       nanoid: 5.1.11
     transitivePeerDependencies:
@@ -2408,10 +2408,10 @@ snapshots:
       - snappy
       - socks
 
-  '@objectstack/driver-sql@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/driver-sql@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       knex: 3.2.10(better-sqlite3@12.10.0)
       nanoid: 5.1.11
     optionalDependencies:
@@ -2423,11 +2423,11 @@ snapshots:
       - pg-query-stream
       - supports-color
 
-  '@objectstack/driver-sqlite-wasm@7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)':
+  '@objectstack/driver-sqlite-wasm@8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-sql': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-sql': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       knex: 3.2.10(better-sqlite3@12.10.0)
       nanoid: 5.1.11
       sql.js: 1.14.1
@@ -2443,36 +2443,48 @@ snapshots:
       - supports-color
       - tedious
 
-  '@objectstack/formula@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/formula@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
       '@marcbachmann/cel-js': 7.6.1
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/metadata-core@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/mcp@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - ai
+      - supports-color
+
+  '@objectstack/metadata-core@8.0.1(ai@6.0.194(zod@4.4.3))':
+    dependencies:
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/metadata-fs@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/metadata-fs@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.194(zod@4.4.3))
       chokidar: 5.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/metadata@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/metadata@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/metadata-fs': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata-fs': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       chokidar: 5.0.0
       glob: 13.0.6
       js-yaml: 4.2.0
@@ -2481,62 +2493,62 @@ snapshots:
       - ai
       - vitest
 
-  '@objectstack/objectql@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/objectql@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/formula': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       ajv: 8.20.0
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/observability@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/observability@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/platform-objects@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/platform-objects@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-    transitivePeerDependencies:
-      - ai
-      - vitest
-
-  '@objectstack/plugin-approvals@7.7.0(ai@6.0.194(zod@4.4.3))':
-    dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/formula': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-audit@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-approvals@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-auth@7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@objectstack/plugin-audit@8.0.1(ai@6.0.194(zod@4.4.3))':
+    dependencies:
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+    transitivePeerDependencies:
+      - ai
+      - vitest
+
+  '@objectstack/plugin-auth@8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@better-auth/core': 1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/oauth-provider': 1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-auth@1.6.13(@opentelemetry/api@1.9.1)(better-sqlite3@12.10.0)(mongodb@7.2.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(better-call@1.3.5(zod@4.4.3))
       '@noble/hashes': 2.2.0
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       better-auth: 1.6.13(@opentelemetry/api@1.9.1)(better-sqlite3@12.10.0)(mongodb@7.2.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@better-auth/utils'
@@ -2568,127 +2580,115 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/plugin-email@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-email@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-hono-server@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-hono-server@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
       '@hono/node-server': 2.0.4(hono@4.12.23)
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       hono: 4.12.23
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-mcp-server@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-org-scoping@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - ai
-      - supports-color
-
-  '@objectstack/plugin-org-scoping@7.7.0(ai@6.0.194(zod@4.4.3))':
-    dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-reports@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-reports@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-security@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-security@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-sharing@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-sharing@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/objectql': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/objectql': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-trigger-record-change@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-trigger-record-change@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-trigger-schedule@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-trigger-schedule@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-webhooks@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-webhooks@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-messaging': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-messaging': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/rest@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/rest@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-package': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-package': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/runtime@7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@objectstack/runtime@8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-memory': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-sql': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-sqlite-wasm': 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
-      '@objectstack/formula': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/metadata': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/objectql': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/observability': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-auth': 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@objectstack/plugin-org-scoping': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-security': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/rest': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-cluster': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-i18n': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-memory': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-sql': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-sqlite-wasm': 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+      '@objectstack/formula': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/objectql': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-auth': 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/plugin-org-scoping': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-security': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/rest': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-cluster': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-i18n': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       quickjs-emscripten: 0.32.0
       zod: 4.4.3
     optionalDependencies:
-      '@objectstack/driver-mongodb': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-mongodb': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@better-auth/utils'
@@ -2732,139 +2732,139 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/service-ai@7.7.0(@ai-sdk/gateway@3.0.122(zod@4.4.3))':
+  '@objectstack/service-ai@8.0.1(@ai-sdk/gateway@3.0.122(zod@4.4.3))':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/formula': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       ai: 6.0.194(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       '@ai-sdk/gateway': 3.0.122(zod@4.4.3)
 
-  '@objectstack/service-analytics@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-analytics@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-automation@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-automation@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/formula': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cache@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-cache@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/observability': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cluster@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-cluster@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-datasource@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-datasource@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-feed@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-feed@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-i18n@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-i18n@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-job@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-job@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       croner: 10.0.1
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-messaging@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-messaging@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-package@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-package@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-queue@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-queue@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-    transitivePeerDependencies:
-      - ai
-      - vitest
-
-  '@objectstack/service-realtime@7.7.0(ai@6.0.194(zod@4.4.3))':
-    dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-settings@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-realtime@8.0.1(ai@6.0.194(zod@4.4.3))':
+    dependencies:
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+    transitivePeerDependencies:
+      - ai
+      - vitest
+
+  '@objectstack/service-settings@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
       '@noble/ciphers': 2.2.0
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-storage@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-storage@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/observability': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/spec@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/spec@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
       zod: 4.4.3
     optionalDependencies:
       ai: 6.0.194(zod@4.4.3)
 
-  '@objectstack/types@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/types@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,12 @@
 packages:
   - 'packages/*'
+allowBuilds:
+  better-sqlite3: set this to true or false
+  esbuild: set this to true or false
+# pnpm 10 no longer reads `pnpm.onlyBuiltDependencies` from package.json — it
+# must live here. These deps have native/postinstall build steps.
+onlyBuiltDependencies:
+  - better-sqlite3
+  - esbuild
+  - sharp
+  - msw


### PR DESCRIPTION
Upgrade all `@objectstack/*` deps from `^7.7.0` to `^8.0.1` across every package.

## Breaking changes adapted
- **`defineDataset` → `defineSeed`** — seed helper renamed in 8.0 (`defineDataset` is now the analytics dataset in `@objectstack/spec/ui`).
- **Stricter seed typing** — 8.0 constrains lookup/master_detail seed values to `string | null` (non-string reference values crash persistent SQLite):
  - `project`: reference-by-object `{ name: 'X' }` → natural-key string `'X'` (correctness fix).
  - `content` / `todo`: multi-value lookup arrays (`target_channels`, `labels`) kept via a typed `multiRef` helper (framework has no `multiple: true`-aware seed overload yet).
- **pnpm 10**: `onlyBuiltDependencies` moved from `package.json` to `pnpm-workspace.yaml`.

## Verification
- `pnpm typecheck` ✓ 0 errors (all packages)
- `pnpm build` ✓ all 9 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)