### PR TITLE
feat(analytics): migrate all dashboards to dataset dual-form (ADR-0021)

### DIFF
--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -12,10 +12,10 @@
     "clean": "rm -rf .objectstack/marketplace-packages dist"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/all/scripts/compile-marketplace.mjs
+++ b/packages/all/scripts/compile-marketplace.mjs
@@ -71,6 +71,7 @@ const CONCAT_FIELDS = [
   'views',
   'pages',
   'dashboards',
+  'datasets',
   'reports',
   'actions',
   'themes',

--- a/packages/compliance/objectstack.config.ts
+++ b/packages/compliance/objectstack.config.ts
@@ -6,6 +6,7 @@ import * as objects from './src/objects/index.js';
 import * as views from './src/views/index.js';
 import * as pages from './src/pages/index.js';
 import * as dashboards from './src/dashboards/index.js';
+import * as datasets from './src/datasets/index.js';
 import * as profiles from './src/profiles/index.js';
 import * as apps from './src/apps/index.js';
 import { ComplianceTranslations } from './src/translations/index.js';
@@ -30,6 +31,7 @@ export default defineStack({
   views: Object.values(views),
   pages: Object.values(pages),
   dashboards: Object.values(dashboards),
+  datasets: Object.values(datasets),
   permissions: Object.values(profiles),
   apps: Object.values(apps),
   flows: allFlows,

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/compliance/src/dashboards/control_posture.dashboard.ts
+++ b/packages/compliance/src/dashboards/control_posture.dashboard.ts
@@ -41,6 +41,7 @@ export const ControlPostureDashboard: Dashboard = {
   widgets: [
     {
       id: 'passing_controls',
+      dataset: 'compliance_control_metrics', values: ['control_count'],
       title: 'Controls Passing',
       type: 'metric',
       object: 'compliance_control',
@@ -52,6 +53,7 @@ export const ControlPostureDashboard: Dashboard = {
     },
     {
       id: 'failing_controls',
+      dataset: 'compliance_control_metrics', values: ['control_count'],
       title: 'Failing or Partial',
       type: 'metric',
       object: 'compliance_control',
@@ -63,6 +65,7 @@ export const ControlPostureDashboard: Dashboard = {
     },
     {
       id: 'expiring_evidence',
+      dataset: 'compliance_evidence_metrics', values: ['evidence_count'],
       title: 'Evidence Expiring ≤ 30d',
       type: 'metric',
       object: 'compliance_evidence',
@@ -77,6 +80,7 @@ export const ControlPostureDashboard: Dashboard = {
     },
     {
       id: 'in_progress_assessments',
+      dataset: 'compliance_assessment_metrics', values: ['assessment_count'],
       title: 'Assessments In Progress',
       type: 'metric',
       object: 'compliance_assessment',
@@ -88,6 +92,7 @@ export const ControlPostureDashboard: Dashboard = {
     },
     {
       id: 'failing_table',
+      dataset: 'compliance_control_metrics', values: ['control_count'],
       title: 'Failing Controls (Action Required)',
       type: 'table',
       object: 'compliance_control',
@@ -105,6 +110,7 @@ export const ControlPostureDashboard: Dashboard = {
     },
     {
       id: 'expiring_evidence_table',
+      dataset: 'compliance_evidence_metrics', values: ['evidence_count'],
       title: 'Evidence Expiring Soon',
       type: 'table',
       object: 'compliance_evidence',
@@ -122,6 +128,7 @@ export const ControlPostureDashboard: Dashboard = {
     },
     {
       id: 'assessments_by_month',
+      dataset: 'compliance_assessment_metrics', dimensions: ['assessed_at'], values: ['assessment_count'],
       title: 'Assessments Completed by Month (last 12 months)',
       type: 'line',
       object: 'compliance_assessment',

--- a/packages/compliance/src/data/index.ts
+++ b/packages/compliance/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Framework } from '../objects/compliance_framework.object';
 import { Control } from '../objects/compliance_control.object';
@@ -15,7 +15,7 @@ import { Assessment } from '../objects/compliance_assessment.object';
  *   • 5 assessments covering planned / in_progress / passed / failed / partial
  */
 
-const frameworks = defineDataset(Framework, {
+const frameworks = defineSeed(Framework, {
   mode: 'upsert',
   externalId: 'short_name',
   records: [
@@ -47,7 +47,7 @@ const frameworks = defineDataset(Framework, {
   ],
 });
 
-const controls = defineDataset(Control, {
+const controls = defineSeed(Control, {
   mode: 'upsert',
   externalId: 'code',
   records: [
@@ -120,7 +120,7 @@ const controls = defineDataset(Control, {
   ],
 });
 
-const evidence = defineDataset(Evidence, {
+const evidence = defineSeed(Evidence, {
   mode: 'upsert',
   externalId: 'title',
   records: [
@@ -186,7 +186,7 @@ const evidence = defineDataset(Evidence, {
   ],
 });
 
-const assessments = defineDataset(Assessment, {
+const assessments = defineSeed(Assessment, {
   mode: 'upsert',
   externalId: 'title',
   records: [

--- a/packages/compliance/src/datasets/compliance_assessment.dataset.ts
+++ b/packages/compliance/src/datasets/compliance_assessment.dataset.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for compliance_assessment. */
+export const ComplianceAssessmentDataset = defineDataset({
+  name: 'compliance_assessment_metrics',
+  label: 'compliance_assessment metrics',
+  object: 'compliance_assessment',
+  dimensions: [
+    { name: 'assessed_at', label: 'assessed_at', field: 'assessed_at', type: 'date' },
+  ],
+  measures: [
+    { name: 'assessment_count', label: 'assessment_count', aggregate: 'count' },
+  ],
+});

--- a/packages/compliance/src/datasets/compliance_control.dataset.ts
+++ b/packages/compliance/src/datasets/compliance_control.dataset.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for compliance_control. */
+export const ComplianceControlDataset = defineDataset({
+  name: 'compliance_control_metrics',
+  label: 'compliance_control metrics',
+  object: 'compliance_control',
+  dimensions: [],
+  measures: [
+    { name: 'control_count', label: 'control_count', aggregate: 'count' },
+  ],
+});

--- a/packages/compliance/src/datasets/compliance_evidence.dataset.ts
+++ b/packages/compliance/src/datasets/compliance_evidence.dataset.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for compliance_evidence. */
+export const ComplianceEvidenceDataset = defineDataset({
+  name: 'compliance_evidence_metrics',
+  label: 'compliance_evidence metrics',
+  object: 'compliance_evidence',
+  dimensions: [],
+  measures: [
+    { name: 'evidence_count', label: 'evidence_count', aggregate: 'count' },
+  ],
+});

--- a/packages/compliance/src/datasets/index.ts
+++ b/packages/compliance/src/datasets/index.ts
@@ -1,0 +1,3 @@
+export { ComplianceControlDataset } from './compliance_control.dataset.js';
+export { ComplianceEvidenceDataset } from './compliance_evidence.dataset.js';
+export { ComplianceAssessmentDataset } from './compliance_assessment.dataset.js';

--- a/packages/content/objectstack.config.ts
+++ b/packages/content/objectstack.config.ts
@@ -6,6 +6,7 @@ import * as objects from './src/objects/index.js';
 import * as views from './src/views/index.js';
 import * as pages from './src/pages/index.js';
 import * as dashboards from './src/dashboards/index.js';
+import * as datasets from './src/datasets/index.js';
 import * as profiles from './src/profiles/index.js';
 import * as apps from './src/apps/index.js';
 import { ContentTranslations } from './src/translations/index.js';
@@ -33,6 +34,7 @@ export default defineStack({
   views: Object.values(views),
   pages: Object.values(pages),
   dashboards: Object.values(dashboards),
+  datasets: Object.values(datasets),
   permissions: Object.values(profiles),
   apps: Object.values(apps),
   flows: allFlows,

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/content/src/dashboards/editorial_calendar.dashboard.ts
+++ b/packages/content/src/dashboards/editorial_calendar.dashboard.ts
@@ -30,6 +30,7 @@ export const EditorialCalendarDashboard: Dashboard = {
   widgets: [
     {
       id: 'pieces_scheduled',
+      dataset: 'content_piece_metrics', values: ['piece_count'],
       title: 'Pieces Scheduled (30d)',
       type: 'metric',
       object: 'content_piece',
@@ -44,6 +45,7 @@ export const EditorialCalendarDashboard: Dashboard = {
     },
     {
       id: 'pieces_in_review',
+      dataset: 'content_piece_metrics', values: ['piece_count'],
       title: 'Awaiting Approval',
       type: 'metric',
       object: 'content_piece',
@@ -55,6 +57,7 @@ export const EditorialCalendarDashboard: Dashboard = {
     },
     {
       id: 'pieces_published_30d',
+      dataset: 'content_piece_metrics', values: ['piece_count'],
       title: 'Published (30d)',
       type: 'metric',
       object: 'content_piece',
@@ -70,6 +73,7 @@ export const EditorialCalendarDashboard: Dashboard = {
     },
     {
       id: 'pieces_overdue',
+      dataset: 'content_piece_metrics', values: ['piece_count'],
       title: 'Overdue',
       type: 'metric',
       object: 'content_piece',
@@ -85,6 +89,7 @@ export const EditorialCalendarDashboard: Dashboard = {
 
     {
       id: 'calendar_main',
+      dataset: 'content_piece_metrics', values: ['piece_count'],
       title: 'Upcoming Calendar',
       type: 'table',
       object: 'content_piece',
@@ -102,6 +107,7 @@ export const EditorialCalendarDashboard: Dashboard = {
     },
     {
       id: 'publications_by_channel',
+      dataset: 'content_publication_metrics', dimensions: ['channel'], values: ['publication_count'],
       title: 'Publications by Channel (30d)',
       type: 'pie',
       object: 'content_publication',
@@ -113,6 +119,7 @@ export const EditorialCalendarDashboard: Dashboard = {
     },
     {
       id: 'published_by_month',
+      dataset: 'content_piece_metrics', dimensions: ['published_at'], values: ['piece_count'],
       title: 'Published Pieces by Month (last 12 months)',
       type: 'line',
       object: 'content_piece',

--- a/packages/content/src/dashboards/roi_by_channel.dashboard.ts
+++ b/packages/content/src/dashboards/roi_by_channel.dashboard.ts
@@ -32,6 +32,7 @@ export const RoiByChannelDashboard: Dashboard = {
   widgets: [
     {
       id: 'total_views_90d',
+      dataset: 'content_publication_metrics', values: ['sum_total_views'],
       title: 'Views (90d)',
       type: 'metric',
       object: 'content_publication',
@@ -45,6 +46,7 @@ export const RoiByChannelDashboard: Dashboard = {
     },
     {
       id: 'total_clicks_90d',
+      dataset: 'content_publication_metrics', values: ['sum_total_clicks'],
       title: 'Clicks (90d)',
       type: 'metric',
       object: 'content_publication',
@@ -58,6 +60,7 @@ export const RoiByChannelDashboard: Dashboard = {
     },
     {
       id: 'total_signups_90d',
+      dataset: 'content_publication_metrics', values: ['sum_total_signups'],
       title: 'Signups (90d)',
       type: 'metric',
       object: 'content_publication',
@@ -71,6 +74,7 @@ export const RoiByChannelDashboard: Dashboard = {
     },
     {
       id: 'total_revenue_90d',
+      dataset: 'content_publication_metrics', values: ['sum_total_revenue'],
       title: 'Attributed Revenue (90d)',
       type: 'metric',
       object: 'content_publication',
@@ -85,6 +89,7 @@ export const RoiByChannelDashboard: Dashboard = {
 
     {
       id: 'views_by_channel_bar',
+      dataset: 'content_publication_metrics', dimensions: ['channel'], values: ['sum_total_views'],
       title: 'Views by Channel (90d)',
       type: 'bar',
       object: 'content_publication',
@@ -98,6 +103,7 @@ export const RoiByChannelDashboard: Dashboard = {
     },
     {
       id: 'signups_trend',
+      dataset: 'content_metric_metrics', dimensions: ['period_start'], values: ['sum_signups'],
       title: 'Signups by Week (90d)',
       type: 'line',
       object: 'content_metric',
@@ -119,6 +125,7 @@ export const RoiByChannelDashboard: Dashboard = {
 
     {
       id: 'top_publications',
+      dataset: 'content_publication_metrics', values: ['publication_count'],
       title: 'Top 10 Publications by Signups',
       type: 'table',
       object: 'content_publication',

--- a/packages/content/src/dashboards/today_workbench.dashboard.ts
+++ b/packages/content/src/dashboards/today_workbench.dashboard.ts
@@ -29,6 +29,7 @@ export const TodayWorkbenchDashboard: Dashboard = {
   widgets: [
     {
       id: 'my_drafts_in_flight',
+      dataset: 'content_piece_metrics', values: ['piece_count'],
       title: 'My Drafts',
       type: 'metric',
       object: 'content_piece',
@@ -43,6 +44,7 @@ export const TodayWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'my_pieces_in_review',
+      dataset: 'content_piece_metrics', values: ['piece_count'],
       title: 'In Review',
       type: 'metric',
       object: 'content_piece',
@@ -57,6 +59,7 @@ export const TodayWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'scheduled_this_week',
+      dataset: 'content_piece_metrics', values: ['piece_count'],
       title: 'Scheduled This Week',
       type: 'metric',
       object: 'content_piece',
@@ -71,6 +74,7 @@ export const TodayWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'published_last_7d',
+      dataset: 'content_piece_metrics', values: ['piece_count'],
       title: 'Published Last 7d',
       type: 'metric',
       object: 'content_piece',
@@ -87,6 +91,7 @@ export const TodayWorkbenchDashboard: Dashboard = {
 
     {
       id: 'my_pieces_table',
+      dataset: 'content_piece_metrics', values: ['piece_count'],
       title: 'Pieces I own (or unassigned), not done',
       type: 'table',
       object: 'content_piece',
@@ -105,6 +110,7 @@ export const TodayWorkbenchDashboard: Dashboard = {
 
     {
       id: 'signals_to_triage',
+      dataset: 'content_signal_metrics', values: ['signal_count'],
       title: 'Signals to Triage',
       type: 'table',
       object: 'content_signal',

--- a/packages/content/src/data/index.ts
+++ b/packages/content/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Competitor } from '../objects/content_competitor.object';
 import { Channel } from '../objects/content_channel.object';
@@ -11,6 +11,13 @@ import { Piece } from '../objects/content_piece.object';
 import { Publication } from '../objects/content_publication.object';
 import { Metric } from '../objects/content_metric.object';
 import { Cta } from '../objects/content_cta.object';
+
+// @objectstack 8.0.1: `defineSeed` types lookup/master_detail fields as
+// `string | null` and has no `multiple: true`-aware overload yet, so a
+// multi-value lookup seeded with an array fails typecheck. `multiRef` keeps
+// the array value (correct at runtime) while satisfying the field type.
+const multiRef = (ids: string[]): string => ids as unknown as string;
+
 
 /**
  * Seed data — realistic editorial workload covering the full template
@@ -31,7 +38,7 @@ import { Cta } from '../objects/content_cta.object';
  * changing the seed call sites.
  */
 
-const competitors = defineDataset(Competitor, {
+const competitors = defineSeed(Competitor, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -77,7 +84,7 @@ const competitors = defineDataset(Competitor, {
   ],
 });
 
-const channels = defineDataset(Channel, {
+const channels = defineSeed(Channel, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -124,7 +131,7 @@ const channels = defineDataset(Channel, {
   ],
 });
 
-const templates = defineDataset(ContentTemplate, {
+const templates = defineSeed(ContentTemplate, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -158,7 +165,7 @@ const templates = defineDataset(ContentTemplate, {
   ],
 });
 
-const signals = defineDataset(Signal, {
+const signals = defineSeed(Signal, {
   mode: 'upsert',
   externalId: 'headline',
   records: [
@@ -285,7 +292,7 @@ const signals = defineDataset(Signal, {
   ],
 });
 
-const topics = defineDataset(Topic, {
+const topics = defineSeed(Topic, {
   mode: 'upsert',
   externalId: 'title',
   records: [
@@ -377,7 +384,7 @@ const topics = defineDataset(Topic, {
   ],
 });
 
-const pieces = defineDataset(Piece, {
+const pieces = defineSeed(Piece, {
   mode: 'upsert',
   externalId: 'title',
   records: [
@@ -388,7 +395,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'backlog',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       summary: 'Side-by-side feature comparison with honest "they win here" sections.',
       tags: 'comparison, seo',
     },
@@ -399,7 +406,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'backlog',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       tags: 'ops, culture',
     },
     {
@@ -409,7 +416,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'backlog',
       format: 'listicle',
-      target_channels: ['Company Blog', 'Weekly Newsletter'],
+      target_channels: multiRef(['Company Blog', 'Weekly Newsletter']),
       tags: 'design, opinion',
     },
     {
@@ -419,7 +426,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'drafting',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       word_count_target: 1800,
       body_outline:
         '# The marketing metrics dashboard we actually use\n\n## What we track\n## What we stopped tracking\n## The dashboard itself\n## CTA',
@@ -433,7 +440,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'drafting',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       word_count_target: 600,
       body_outline:
         '# Picking the right region\n\n## A 30-second decision tree\n## One-line per region\n## What changes if you guess wrong\n## CTA',
@@ -446,7 +453,7 @@ const pieces = defineDataset(Piece, {
       template: 'Customer Story',
       status: 'drafting',
       format: 'case_study',
-      target_channels: ['Company Blog', 'LinkedIn Company Page'],
+      target_channels: multiRef(['Company Blog', 'LinkedIn Company Page']),
       word_count_target: 1200,
       tags: 'case-study, enterprise',
     },
@@ -457,7 +464,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'in_review',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       word_count_target: 1500,
       body_outline:
         '# How our SOC 2 program actually works\n\n## What SOC 2 actually requires\n## How we operationalised it\n## Where to find our report\n## CTA — book a security review',
@@ -472,7 +479,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'in_review',
       format: 'long_form',
-      target_channels: ['Company Blog', 'Weekly Newsletter'],
+      target_channels: multiRef(['Company Blog', 'Weekly Newsletter']),
       word_count_target: 2200,
       submitted_at: cel`daysAgo(1)`,
       summary: 'Real numbers, real runbook. Six-month bill, what we cut, what we kept.',
@@ -485,7 +492,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'approved',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       word_count_target: 500,
       submitted_at: cel`daysAgo(4)`,
       approved_at: cel`daysAgo(2)`,
@@ -498,7 +505,7 @@ const pieces = defineDataset(Piece, {
       template: 'Weekly Newsletter Issue',
       status: 'scheduled',
       format: 'newsletter',
-      target_channels: ['Weekly Newsletter'],
+      target_channels: multiRef(['Weekly Newsletter']),
       publish_at: cel`daysFromNow(2)`,
       submitted_at: cel`daysAgo(5)`,
       approved_at: cel`daysAgo(3)`,
@@ -512,7 +519,7 @@ const pieces = defineDataset(Piece, {
       template: 'Weekly Newsletter Issue',
       status: 'scheduled',
       format: 'newsletter',
-      target_channels: ['Weekly Newsletter'],
+      target_channels: multiRef(['Weekly Newsletter']),
       publish_at: cel`daysFromNow(9)`,
       submitted_at: cel`daysAgo(2)`,
       approved_at: cel`daysAgo(1)`,
@@ -526,7 +533,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'published',
       format: 'long_form',
-      target_channels: ['Company Blog', 'LinkedIn Company Page'],
+      target_channels: multiRef(['Company Blog', 'LinkedIn Company Page']),
       publish_at: cel`daysAgo(8)`,
       submitted_at: cel`daysAgo(14)`,
       approved_at: cel`daysAgo(10)`,
@@ -542,7 +549,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'published',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       publish_at: cel`daysAgo(22)`,
       submitted_at: cel`daysAgo(28)`,
       approved_at: cel`daysAgo(24)`,
@@ -557,7 +564,7 @@ const pieces = defineDataset(Piece, {
       template: 'Long-Form Article',
       status: 'archived',
       format: 'long_form',
-      target_channels: ['Company Blog'],
+      target_channels: multiRef(['Company Blog']),
       publish_at: cel`daysAgo(160)`,
       submitted_at: cel`daysAgo(170)`,
       approved_at: cel`daysAgo(165)`,
@@ -570,7 +577,7 @@ const pieces = defineDataset(Piece, {
   ],
 });
 
-const publications = defineDataset(Publication, {
+const publications = defineSeed(Publication, {
   mode: 'upsert',
   externalId: 'public_url',
   records: [
@@ -624,7 +631,7 @@ const publications = defineDataset(Publication, {
 // 6 weekly snapshots per recent publication, 3 monthly snapshots for the
 // archived one. Each row is one period; the publication_rollup flow keeps
 // totals in sync (the publication.total_* above is a starting denormal).
-const metrics = defineDataset(Metric, {
+const metrics = defineSeed(Metric, {
   mode: 'upsert',
   externalId: 'note',
   records: [
@@ -682,7 +689,7 @@ const metrics = defineDataset(Metric, {
   ],
 });
 
-const ctas = defineDataset(Cta, {
+const ctas = defineSeed(Cta, {
   mode: 'upsert',
   externalId: 'variant',
   records: [

--- a/packages/content/src/datasets/content_metric.dataset.ts
+++ b/packages/content/src/datasets/content_metric.dataset.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for content_metric. */
+export const ContentMetricDataset = defineDataset({
+  name: 'content_metric_metrics',
+  label: 'content_metric metrics',
+  object: 'content_metric',
+  dimensions: [
+    { name: 'period_start', label: 'period_start', field: 'period_start', type: 'string' },
+  ],
+  measures: [
+    { name: 'sum_signups', label: 'sum_signups', aggregate: 'sum', field: 'signups' },
+  ],
+});

--- a/packages/content/src/datasets/content_piece.dataset.ts
+++ b/packages/content/src/datasets/content_piece.dataset.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for content_piece. */
+export const ContentPieceDataset = defineDataset({
+  name: 'content_piece_metrics',
+  label: 'content_piece metrics',
+  object: 'content_piece',
+  dimensions: [
+    { name: 'published_at', label: 'published_at', field: 'published_at', type: 'date' },
+  ],
+  measures: [
+    { name: 'piece_count', label: 'piece_count', aggregate: 'count' },
+  ],
+});

--- a/packages/content/src/datasets/content_publication.dataset.ts
+++ b/packages/content/src/datasets/content_publication.dataset.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for content_publication. */
+export const ContentPublicationDataset = defineDataset({
+  name: 'content_publication_metrics',
+  label: 'content_publication metrics',
+  object: 'content_publication',
+  dimensions: [
+    { name: 'channel', label: 'channel', field: 'channel', type: 'string' },
+  ],
+  measures: [
+    { name: 'publication_count', label: 'publication_count', aggregate: 'count' },
+    { name: 'sum_total_views', label: 'sum_total_views', aggregate: 'sum', field: 'total_views' },
+    { name: 'sum_total_clicks', label: 'sum_total_clicks', aggregate: 'sum', field: 'total_clicks' },
+    { name: 'sum_total_signups', label: 'sum_total_signups', aggregate: 'sum', field: 'total_signups' },
+    { name: 'sum_total_revenue', label: 'sum_total_revenue', aggregate: 'sum', field: 'total_revenue' },
+  ],
+});

--- a/packages/content/src/datasets/content_signal.dataset.ts
+++ b/packages/content/src/datasets/content_signal.dataset.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for content_signal. */
+export const ContentSignalDataset = defineDataset({
+  name: 'content_signal_metrics',
+  label: 'content_signal metrics',
+  object: 'content_signal',
+  dimensions: [],
+  measures: [
+    { name: 'signal_count', label: 'signal_count', aggregate: 'count' },
+  ],
+});

--- a/packages/content/src/datasets/index.ts
+++ b/packages/content/src/datasets/index.ts
@@ -1,0 +1,4 @@
+export { ContentPieceDataset } from './content_piece.dataset.js';
+export { ContentPublicationDataset } from './content_publication.dataset.js';
+export { ContentMetricDataset } from './content_metric.dataset.js';
+export { ContentSignalDataset } from './content_signal.dataset.js';

--- a/packages/contracts/objectstack.config.ts
+++ b/packages/contracts/objectstack.config.ts
@@ -6,6 +6,7 @@ import * as objects from './src/objects/index.js';
 import * as views from './src/views/index.js';
 import * as pages from './src/pages/index.js';
 import * as dashboards from './src/dashboards/index.js';
+import * as datasets from './src/datasets/index.js';
 import * as profiles from './src/profiles/index.js';
 import * as apps from './src/apps/index.js';
 import { ContractsTranslations } from './src/translations/index.js';
@@ -32,6 +33,7 @@ export default defineStack({
   views: Object.values(views),
   pages: Object.values(pages),
   dashboards: Object.values(dashboards),
+  datasets: Object.values(datasets),
   permissions: Object.values(profiles),
   apps: Object.values(apps),
   flows: allFlows,

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/contracts/src/dashboards/renewals_at_risk.dashboard.ts
+++ b/packages/contracts/src/dashboards/renewals_at_risk.dashboard.ts
@@ -33,6 +33,7 @@ export const RenewalsAtRiskDashboard: Dashboard = {
   widgets: [
     {
       id: 'expiring_60',
+      dataset: 'contracts_contract_metrics', values: ['contract_count'],
       title: 'Expiring ≤ 60 days',
       type: 'metric',
       object: 'contracts_contract',
@@ -50,6 +51,7 @@ export const RenewalsAtRiskDashboard: Dashboard = {
     },
     {
       id: 'auto_renewing_30',
+      dataset: 'contracts_contract_metrics', values: ['contract_count'],
       title: 'Auto-Renewing ≤ 30d',
       type: 'metric',
       object: 'contracts_contract',
@@ -65,6 +67,7 @@ export const RenewalsAtRiskDashboard: Dashboard = {
     },
     {
       id: 'pending_approval',
+      dataset: 'contracts_contract_metrics', values: ['contract_count'],
       title: 'Pending Approval',
       type: 'metric',
       object: 'contracts_contract',
@@ -79,6 +82,7 @@ export const RenewalsAtRiskDashboard: Dashboard = {
     },
     {
       id: 'active_total_value',
+      dataset: 'contracts_contract_metrics', values: ['sum_total_value'],
       title: 'Active Portfolio Value',
       type: 'metric',
       object: 'contracts_contract',
@@ -91,6 +95,7 @@ export const RenewalsAtRiskDashboard: Dashboard = {
     },
     {
       id: 'expiring_table',
+      dataset: 'contracts_contract_metrics', values: ['contract_count'],
       title: 'Expiring Contracts (Next 60d)',
       type: 'table',
       object: 'contracts_contract',
@@ -112,6 +117,7 @@ export const RenewalsAtRiskDashboard: Dashboard = {
     },
     {
       id: 'pending_obligations',
+      dataset: 'contracts_obligation_metrics', values: ['obligation_count'],
       title: 'Open Obligations',
       type: 'table',
       object: 'contracts_obligation',
@@ -126,6 +132,7 @@ export const RenewalsAtRiskDashboard: Dashboard = {
     },
     {
       id: 'signed_by_month',
+      dataset: 'contracts_contract_metrics', dimensions: ['signed_date'], values: ['contract_count'],
       title: 'Contracts Signed by Month (last 12 months)',
       type: 'line',
       object: 'contracts_contract',

--- a/packages/contracts/src/data/index.ts
+++ b/packages/contracts/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Party } from '../objects/contracts_party.object';
 import { Contract } from '../objects/contracts_contract.object';
@@ -22,7 +22,7 @@ import { Obligation } from '../objects/contracts_obligation.object';
  *   OBLIGATIONS 6
  */
 
-const parties = defineDataset(Party, {
+const parties = defineSeed(Party, {
   mode: 'upsert',
   externalId: 'legal_name',
   records: [
@@ -59,7 +59,7 @@ const parties = defineDataset(Party, {
   ],
 });
 
-const contracts = defineDataset(Contract, {
+const contracts = defineSeed(Contract, {
   mode: 'upsert',
   externalId: 'title',
   records: [
@@ -151,7 +151,7 @@ const contracts = defineDataset(Contract, {
   ],
 });
 
-const obligations = defineDataset(Obligation, {
+const obligations = defineSeed(Obligation, {
   mode: 'upsert',
   externalId: 'summary',
   records: [

--- a/packages/contracts/src/datasets/contracts_contract.dataset.ts
+++ b/packages/contracts/src/datasets/contracts_contract.dataset.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for contracts_contract. */
+export const ContractsContractDataset = defineDataset({
+  name: 'contracts_contract_metrics',
+  label: 'contracts_contract metrics',
+  object: 'contracts_contract',
+  dimensions: [
+    { name: 'signed_date', label: 'signed_date', field: 'signed_date', type: 'date' },
+  ],
+  measures: [
+    { name: 'contract_count', label: 'contract_count', aggregate: 'count' },
+    { name: 'sum_total_value', label: 'sum_total_value', aggregate: 'sum', field: 'total_value' },
+  ],
+});

--- a/packages/contracts/src/datasets/contracts_obligation.dataset.ts
+++ b/packages/contracts/src/datasets/contracts_obligation.dataset.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for contracts_obligation. */
+export const ContractsObligationDataset = defineDataset({
+  name: 'contracts_obligation_metrics',
+  label: 'contracts_obligation metrics',
+  object: 'contracts_obligation',
+  dimensions: [],
+  measures: [
+    { name: 'obligation_count', label: 'obligation_count', aggregate: 'count' },
+  ],
+});

--- a/packages/contracts/src/datasets/index.ts
+++ b/packages/contracts/src/datasets/index.ts
@@ -1,0 +1,2 @@
+export { ContractsContractDataset } from './contracts_contract.dataset.js';
+export { ContractsObligationDataset } from './contracts_obligation.dataset.js';

--- a/packages/expense/objectstack.config.ts
+++ b/packages/expense/objectstack.config.ts
@@ -6,6 +6,7 @@ import * as objects from './src/objects/index.js';
 import * as views from './src/views/index.js';
 import * as pages from './src/pages/index.js';
 import * as dashboards from './src/dashboards/index.js';
+import * as datasets from './src/datasets/index.js';
 import * as profiles from './src/profiles/index.js';
 import * as apps from './src/apps/index.js';
 import { ExpenseTranslations } from './src/translations/index.js';
@@ -30,6 +31,7 @@ export default defineStack({
   views: Object.values(views),
   pages: Object.values(pages),
   dashboards: Object.values(dashboards),
+  datasets: Object.values(datasets),
   permissions: Object.values(profiles),
   apps: Object.values(apps),
   flows: allFlows,

--- a/packages/expense/package.json
+++ b/packages/expense/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/expense/src/dashboards/expenses_overview.dashboard.ts
+++ b/packages/expense/src/dashboards/expenses_overview.dashboard.ts
@@ -31,6 +31,7 @@ export const ExpensesOverviewDashboard: Dashboard = {
   widgets: [
     {
       id: 'awaiting_approval',
+      dataset: 'expense_report_metrics', values: ['report_count'],
       title: 'Awaiting Approval',
       type: 'metric',
       object: 'expense_report',
@@ -42,6 +43,7 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'awaiting_reimbursement',
+      dataset: 'expense_report_metrics', values: ['report_count'],
       title: 'To Reimburse',
       type: 'metric',
       object: 'expense_report',
@@ -53,6 +55,7 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'owed_amount',
+      dataset: 'expense_report_metrics', values: ['sum_total_amount'],
       title: 'Owed to Employees ($)',
       type: 'metric',
       object: 'expense_report',
@@ -65,6 +68,7 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'reimbursed_total',
+      dataset: 'expense_report_metrics', values: ['sum_total_amount'],
       title: 'Reimbursed ($)',
       type: 'metric',
       object: 'expense_report',
@@ -77,6 +81,7 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'pending_reports_table',
+      dataset: 'expense_report_metrics', values: ['report_count'],
       title: 'Reports Awaiting Approval',
       type: 'table',
       object: 'expense_report',
@@ -91,6 +96,7 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'to_reimburse_table',
+      dataset: 'expense_report_metrics', values: ['report_count'],
       title: 'Approved — To Reimburse',
       type: 'table',
       object: 'expense_report',
@@ -105,6 +111,7 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'spend_by_category',
+      dataset: 'expense_line_metrics', dimensions: ['category'], values: ['sum_amount'],
       title: 'Spend by Category',
       type: 'bar',
       object: 'expense_line',
@@ -122,6 +129,7 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'spend_by_month',
+      dataset: 'expense_report_metrics', dimensions: ['reimbursed_at'], values: ['sum_total_amount'],
       title: 'Reimbursed by Month (last 12 months)',
       type: 'line',
       object: 'expense_report',

--- a/packages/expense/src/data/index.ts
+++ b/packages/expense/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { ExpenseCategory } from '../objects/expense_category.object';
 import { ExpenseReport } from '../objects/expense_report.object';
@@ -16,7 +16,7 @@ import { ExpenseLine } from '../objects/expense_line.object';
  * relying on the line rollup hook (hooks fire on user edits, not seeds).
  */
 
-const categories = defineDataset(ExpenseCategory, {
+const categories = defineSeed(ExpenseCategory, {
   mode: 'upsert',
   externalId: 'code',
   records: [
@@ -53,7 +53,7 @@ const categories = defineDataset(ExpenseCategory, {
   ],
 });
 
-const reports = defineDataset(ExpenseReport, {
+const reports = defineSeed(ExpenseReport, {
   mode: 'upsert',
   externalId: 'report_number',
   records: [
@@ -126,7 +126,7 @@ const reports = defineDataset(ExpenseReport, {
   ],
 });
 
-const lines = defineDataset(ExpenseLine, {
+const lines = defineSeed(ExpenseLine, {
   mode: 'upsert',
   externalId: 'description',
   records: [

--- a/packages/expense/src/datasets/expense_line.dataset.ts
+++ b/packages/expense/src/datasets/expense_line.dataset.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for expense_line. */
+export const ExpenseLineDataset = defineDataset({
+  name: 'expense_line_metrics',
+  label: 'expense_line metrics',
+  object: 'expense_line',
+  dimensions: [
+    { name: 'category', label: 'category', field: 'category', type: 'string' },
+  ],
+  measures: [
+    { name: 'sum_amount', label: 'sum_amount', aggregate: 'sum', field: 'amount' },
+  ],
+});

--- a/packages/expense/src/datasets/expense_report.dataset.ts
+++ b/packages/expense/src/datasets/expense_report.dataset.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for expense_report. */
+export const ExpenseReportDataset = defineDataset({
+  name: 'expense_report_metrics',
+  label: 'expense_report metrics',
+  object: 'expense_report',
+  dimensions: [
+    { name: 'reimbursed_at', label: 'reimbursed_at', field: 'reimbursed_at', type: 'date' },
+  ],
+  measures: [
+    { name: 'report_count', label: 'report_count', aggregate: 'count' },
+    { name: 'sum_total_amount', label: 'sum_total_amount', aggregate: 'sum', field: 'total_amount' },
+  ],
+});

--- a/packages/expense/src/datasets/index.ts
+++ b/packages/expense/src/datasets/index.ts
@@ -1,0 +1,2 @@
+export { ExpenseReportDataset } from './expense_report.dataset.js';
+export { ExpenseLineDataset } from './expense_line.dataset.js';

--- a/packages/helpdesk/objectstack.config.ts
+++ b/packages/helpdesk/objectstack.config.ts
@@ -6,6 +6,7 @@ import * as objects from './src/objects/index.js';
 import * as views from './src/views/index.js';
 import * as pages from './src/pages/index.js';
 import * as dashboards from './src/dashboards/index.js';
+import * as datasets from './src/datasets/index.js';
 import * as profiles from './src/profiles/index.js';
 import * as apps from './src/apps/index.js';
 // portals: declared as metadata (see ./src/portals/index.ts). Wire into
@@ -36,6 +37,7 @@ export default defineStack({
   views: Object.values(views),
   pages: Object.values(pages),
   dashboards: Object.values(dashboards),
+  datasets: Object.values(datasets),
   permissions: Object.values(profiles),
   apps: Object.values(apps),
   // portals: Object.values(portals), // enable after spec@>=6.4 ships kind: 'portal'

--- a/packages/helpdesk/package.json
+++ b/packages/helpdesk/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/helpdesk/src/dashboards/agent_workbench.dashboard.ts
+++ b/packages/helpdesk/src/dashboards/agent_workbench.dashboard.ts
@@ -30,6 +30,7 @@ export const AgentWorkbenchDashboard: Dashboard = {
   widgets: [
     {
       id: 'my_open',
+      dataset: 'ticket_metrics', values: ['ticket_count'],
       title: 'My Open Tickets',
       type: 'metric',
       object: 'helpdesk_ticket',
@@ -44,6 +45,7 @@ export const AgentWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'breaching_resolution',
+      dataset: 'ticket_metrics', values: ['ticket_count'],
       title: 'SLA Breaching',
       type: 'metric',
       object: 'helpdesk_ticket',
@@ -58,6 +60,7 @@ export const AgentWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'angry',
+      dataset: 'ticket_metrics', values: ['ticket_count'],
       title: 'Angry Customers',
       type: 'metric',
       object: 'helpdesk_ticket',
@@ -72,6 +75,7 @@ export const AgentWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'awaiting_triage',
+      dataset: 'ticket_metrics', values: ['ticket_count'],
       title: 'Awaiting Triage',
       type: 'metric',
       object: 'helpdesk_ticket',
@@ -84,6 +88,7 @@ export const AgentWorkbenchDashboard: Dashboard = {
 
     {
       id: 'my_queue_table',
+      dataset: 'ticket_metrics', values: ['ticket_count'],
       title: 'My Queue (Priority Sorted)',
       type: 'table',
       object: 'helpdesk_ticket',
@@ -101,6 +106,7 @@ export const AgentWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'breaching_table',
+      dataset: 'ticket_metrics', values: ['ticket_count'],
       title: 'SLA Breaches',
       type: 'table',
       object: 'helpdesk_ticket',

--- a/packages/helpdesk/src/dashboards/manager_overview.dashboard.ts
+++ b/packages/helpdesk/src/dashboards/manager_overview.dashboard.ts
@@ -26,6 +26,7 @@ export const ManagerOverviewDashboard: Dashboard = {
   widgets: [
     {
       id: 'total_open',
+      dataset: 'ticket_metrics', values: ['ticket_count'],
       title: 'Open Tickets',
       type: 'metric',
       object: 'helpdesk_ticket',
@@ -37,6 +38,7 @@ export const ManagerOverviewDashboard: Dashboard = {
     },
     {
       id: 'breaching_overview',
+      dataset: 'ticket_metrics', values: ['ticket_count'],
       title: 'SLA Breaching',
       type: 'metric',
       object: 'helpdesk_ticket',
@@ -51,6 +53,7 @@ export const ManagerOverviewDashboard: Dashboard = {
     },
     {
       id: 'escalated',
+      dataset: 'ticket_metrics', values: ['ticket_count'],
       title: 'Escalated',
       type: 'metric',
       object: 'helpdesk_ticket',
@@ -62,6 +65,7 @@ export const ManagerOverviewDashboard: Dashboard = {
     },
     {
       id: 'avg_csat',
+      dataset: 'ticket_metrics', values: ['avg_csat'],
       title: 'Avg CSAT',
       type: 'metric',
       object: 'helpdesk_ticket',
@@ -79,6 +83,7 @@ export const ManagerOverviewDashboard: Dashboard = {
 
     {
       id: 'tickets_by_status',
+      dataset: 'ticket_metrics', dimensions: ['status'], values: ['ticket_count'],
       title: 'Tickets by Status',
       type: 'bar',
       object: 'helpdesk_ticket',
@@ -88,6 +93,7 @@ export const ManagerOverviewDashboard: Dashboard = {
     },
     {
       id: 'tickets_by_sentiment',
+      dataset: 'ticket_metrics', dimensions: ['ai_sentiment'], values: ['ticket_count'],
       title: 'Sentiment Distribution',
       type: 'pie',
       object: 'helpdesk_ticket',
@@ -99,6 +105,7 @@ export const ManagerOverviewDashboard: Dashboard = {
 
     {
       id: 'tickets_by_category',
+      dataset: 'ticket_metrics', dimensions: ['ai_category'], values: ['ticket_count'],
       title: 'AI Category Mix',
       type: 'bar',
       object: 'helpdesk_ticket',
@@ -108,6 +115,7 @@ export const ManagerOverviewDashboard: Dashboard = {
     },
     {
       id: 'tickets_by_channel',
+      dataset: 'ticket_metrics', dimensions: ['channel'], values: ['ticket_count'],
       title: 'Volume by Channel',
       type: 'bar',
       object: 'helpdesk_ticket',
@@ -118,6 +126,7 @@ export const ManagerOverviewDashboard: Dashboard = {
 
     {
       id: 'recent_escalated',
+      dataset: 'ticket_metrics', values: ['ticket_count'],
       title: 'Recently Escalated',
       type: 'table',
       object: 'helpdesk_ticket',
@@ -140,6 +149,7 @@ export const ManagerOverviewDashboard: Dashboard = {
     },
     {
       id: 'resolutions_by_day',
+      dataset: 'ticket_metrics', dimensions: ['resolved_at'], values: ['ticket_count'],
       title: 'Resolutions by Day (last 30 days)',
       type: 'line',
       object: 'helpdesk_ticket',

--- a/packages/helpdesk/src/data/index.ts
+++ b/packages/helpdesk/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Customer } from '../objects/helpdesk_customer.object';
 import { Team } from '../objects/helpdesk_team.object';
@@ -20,7 +20,7 @@ import { Message } from '../objects/helpdesk_message.object';
  *   • 8 messages (inbound, outbound, AI-drafted, internal note)
  */
 
-const teams = defineDataset(Team, {
+const teams = defineSeed(Team, {
   mode: 'upsert',
   externalId: 'code',
   records: [
@@ -48,7 +48,7 @@ const teams = defineDataset(Team, {
   ],
 });
 
-const slaPolicies = defineDataset(SLAPolicy, {
+const slaPolicies = defineSeed(SLAPolicy, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -109,7 +109,7 @@ const slaPolicies = defineDataset(SLAPolicy, {
   ],
 });
 
-const customers = defineDataset(Customer, {
+const customers = defineSeed(Customer, {
   mode: 'upsert',
   externalId: 'email',
   records: [
@@ -164,7 +164,7 @@ const customers = defineDataset(Customer, {
   ],
 });
 
-const kbArticles = defineDataset(KBArticle, {
+const kbArticles = defineSeed(KBArticle, {
   mode: 'upsert',
   externalId: 'slug',
   records: [
@@ -240,7 +240,7 @@ const kbArticles = defineDataset(KBArticle, {
   ],
 });
 
-const tickets = defineDataset(Ticket, {
+const tickets = defineSeed(Ticket, {
   mode: 'upsert',
   externalId: 'ticket_number',
   records: [
@@ -481,7 +481,7 @@ const tickets = defineDataset(Ticket, {
   ],
 });
 
-const messages = defineDataset(Message, {
+const messages = defineSeed(Message, {
   mode: 'upsert',
   externalId: 'name',
   records: [

--- a/packages/helpdesk/src/datasets/index.ts
+++ b/packages/helpdesk/src/datasets/index.ts
@@ -1,0 +1,1 @@
+export { TicketDataset } from './ticket.dataset.js';

--- a/packages/helpdesk/src/datasets/ticket.dataset.ts
+++ b/packages/helpdesk/src/datasets/ticket.dataset.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/**
+ * Ticket analytics dataset (ADR-0021) — the semantic source of truth for the
+ * Agent Workbench and Manager Overview dashboards. Widgets bind to it and
+ * select measures/dimensions BY NAME.
+ */
+export const TicketDataset = defineDataset({
+  name: 'ticket_metrics',
+  label: 'Ticket Metrics',
+  description: 'Helpdesk ticket counts and CSAT.',
+  object: 'helpdesk_ticket',
+  dimensions: [
+    { name: 'status', label: 'Status', field: 'status', type: 'string' },
+    { name: 'channel', label: 'Channel', field: 'channel', type: 'string' },
+    { name: 'ai_category', label: 'AI Category', field: 'ai_category', type: 'string' },
+    { name: 'ai_sentiment', label: 'AI Sentiment', field: 'ai_sentiment', type: 'string' },
+    { name: 'priority', label: 'Priority', field: 'priority', type: 'string' },
+    { name: 'resolved_at', label: 'Resolved At', field: 'resolved_at', type: 'date' },
+  ],
+  measures: [
+    { name: 'ticket_count', label: 'Tickets', aggregate: 'count' },
+    { name: 'avg_csat', label: 'Avg CSAT', aggregate: 'avg', field: 'csat_score', format: '0.00' },
+  ],
+});

--- a/packages/hr/objectstack.config.ts
+++ b/packages/hr/objectstack.config.ts
@@ -6,6 +6,7 @@ import * as objects from './src/objects/index.js';
 import * as views from './src/views/index.js';
 import * as pages from './src/pages/index.js';
 import * as dashboards from './src/dashboards/index.js';
+import * as datasets from './src/datasets/index.js';
 import * as profiles from './src/profiles/index.js';
 import * as apps from './src/apps/index.js';
 import { HrTranslations } from './src/translations/index.js';
@@ -33,6 +34,7 @@ export default defineStack({
   views: Object.values(views),
   pages: Object.values(pages),
   dashboards: Object.values(dashboards),
+  datasets: Object.values(datasets),
   permissions: Object.values(profiles),
   apps: Object.values(apps),
   flows: allFlows,

--- a/packages/hr/package.json
+++ b/packages/hr/package.json
@@ -19,17 +19,17 @@
     "test:qa": "node ../../scripts/run-qa.mjs --url http://localhost:4009 --file qa/business-workflow.test.json"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/hr/src/dashboards/hr_admin.dashboard.ts
+++ b/packages/hr/src/dashboards/hr_admin.dashboard.ts
@@ -32,6 +32,7 @@ export const HrAdminDashboard: Dashboard = {
   widgets: [
     {
       id: 'headcount',
+      dataset: 'hr_employee_metrics', values: ['employee_count'],
       title: 'Active Headcount',
       type: 'metric',
       object: 'hr_employee',
@@ -43,6 +44,7 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'on_leave',
+      dataset: 'hr_employee_metrics', values: ['employee_count'],
       title: 'On Leave',
       type: 'metric',
       object: 'hr_employee',
@@ -54,6 +56,7 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'new_hires_30d',
+      dataset: 'hr_employee_metrics', values: ['employee_count'],
       title: 'New Hires (30d)',
       type: 'metric',
       object: 'hr_employee',
@@ -66,6 +69,7 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'pending_time_off',
+      dataset: 'hr_time_off_request_metrics', values: ['request_count'],
       title: 'My Pending Approvals',
       type: 'metric',
       object: 'hr_time_off_request',
@@ -77,6 +81,7 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'expiring_docs',
+      dataset: 'hr_document_metrics', values: ['document_count'],
       title: 'Documents Expiring (30d)',
       type: 'metric',
       object: 'hr_document',
@@ -90,6 +95,7 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'expired_docs',
+      dataset: 'hr_document_metrics', values: ['document_count'],
       title: 'Already Expired',
       type: 'metric',
       object: 'hr_document',
@@ -101,6 +107,7 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'headcount_by_dept',
+      dataset: 'hr_employee_metrics', dimensions: ['department'], values: ['employee_count'],
       title: 'Headcount by Department',
       type: 'bar',
       object: 'hr_employee',
@@ -111,6 +118,7 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'ooo_today',
+      dataset: 'hr_time_off_request_metrics', values: ['request_count'],
       title: 'Out of Office Today',
       type: 'table',
       object: 'hr_time_off_request',
@@ -129,6 +137,7 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'pending_time_off_table',
+      dataset: 'hr_time_off_request_metrics', values: ['request_count'],
       title: 'My Pending Time-Off Requests',
       type: 'table',
       object: 'hr_time_off_request',
@@ -143,6 +152,7 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'expiring_docs_table',
+      dataset: 'hr_document_metrics', values: ['document_count'],
       title: 'Documents Expiring Soon',
       type: 'table',
       object: 'hr_document',
@@ -157,6 +167,7 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'hires_by_month',
+      dataset: 'hr_employee_metrics', dimensions: ['hire_date'], values: ['employee_count'],
       title: 'Hires by Month (last 12 months)',
       type: 'line',
       object: 'hr_employee',

--- a/packages/hr/src/data/index.ts
+++ b/packages/hr/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Department } from '../objects/hr_department.object';
 import { Employee } from '../objects/hr_employee.object';
@@ -16,7 +16,7 @@ import { EmployeeDocument } from '../objects/hr_document.object';
  *   • 5 documents: valid / expiring soon (within 30d) / expired
  */
 
-const departments = defineDataset(Department, {
+const departments = defineSeed(Department, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -32,7 +32,7 @@ const departments = defineDataset(Department, {
   ],
 });
 
-const employees = defineDataset(Employee, {
+const employees = defineSeed(Employee, {
   mode: 'upsert',
   externalId: 'work_email',
   records: [
@@ -134,7 +134,7 @@ const employees = defineDataset(Employee, {
   ],
 });
 
-const timeOff = defineDataset(TimeOffRequest, {
+const timeOff = defineSeed(TimeOffRequest, {
   mode: 'upsert',
   externalId: 'employee',
   records: [
@@ -189,7 +189,7 @@ const timeOff = defineDataset(TimeOffRequest, {
   ],
 });
 
-const documents = defineDataset(EmployeeDocument, {
+const documents = defineSeed(EmployeeDocument, {
   mode: 'upsert',
   externalId: 'name',
   records: [

--- a/packages/hr/src/datasets/hr_document.dataset.ts
+++ b/packages/hr/src/datasets/hr_document.dataset.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for hr_document. */
+export const HrDocumentDataset = defineDataset({
+  name: 'hr_document_metrics',
+  label: 'hr_document metrics',
+  object: 'hr_document',
+  dimensions: [],
+  measures: [
+    { name: 'document_count', label: 'document_count', aggregate: 'count' },
+  ],
+});

--- a/packages/hr/src/datasets/hr_employee.dataset.ts
+++ b/packages/hr/src/datasets/hr_employee.dataset.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for hr_employee. */
+export const HrEmployeeDataset = defineDataset({
+  name: 'hr_employee_metrics',
+  label: 'hr_employee metrics',
+  object: 'hr_employee',
+  dimensions: [
+    { name: 'department', label: 'department', field: 'department', type: 'string' },
+    { name: 'hire_date', label: 'hire_date', field: 'hire_date', type: 'date' },
+  ],
+  measures: [
+    { name: 'employee_count', label: 'employee_count', aggregate: 'count' },
+  ],
+});

--- a/packages/hr/src/datasets/hr_time_off_request.dataset.ts
+++ b/packages/hr/src/datasets/hr_time_off_request.dataset.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for hr_time_off_request. */
+export const HrTimeOffRequestDataset = defineDataset({
+  name: 'hr_time_off_request_metrics',
+  label: 'hr_time_off_request metrics',
+  object: 'hr_time_off_request',
+  dimensions: [],
+  measures: [
+    { name: 'request_count', label: 'request_count', aggregate: 'count' },
+  ],
+});

--- a/packages/hr/src/datasets/index.ts
+++ b/packages/hr/src/datasets/index.ts
@@ -1,0 +1,3 @@
+export { HrEmployeeDataset } from './hr_employee.dataset.js';
+export { HrTimeOffRequestDataset } from './hr_time_off_request.dataset.js';
+export { HrDocumentDataset } from './hr_document.dataset.js';

--- a/packages/procurement/objectstack.config.ts
+++ b/packages/procurement/objectstack.config.ts
@@ -6,6 +6,7 @@ import * as objects from './src/objects/index.js';
 import * as views from './src/views/index.js';
 import * as pages from './src/pages/index.js';
 import * as dashboards from './src/dashboards/index.js';
+import * as datasets from './src/datasets/index.js';
 import * as profiles from './src/profiles/index.js';
 import * as apps from './src/apps/index.js';
 import { ProcurementTranslations } from './src/translations/index.js';
@@ -30,6 +31,7 @@ export default defineStack({
   views: Object.values(views),
   pages: Object.values(pages),
   dashboards: Object.values(dashboards),
+  datasets: Object.values(datasets),
   permissions: Object.values(profiles),
   apps: Object.values(apps),
   flows: allFlows,

--- a/packages/procurement/package.json
+++ b/packages/procurement/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/procurement/src/dashboards/spend_at_a_glance.dashboard.ts
+++ b/packages/procurement/src/dashboards/spend_at_a_glance.dashboard.ts
@@ -35,6 +35,7 @@ export const SpendAtAGlanceDashboard: Dashboard = {
   widgets: [
     {
       id: 'awaiting_approval',
+      dataset: 'procurement_request_metrics', values: ['request_count'],
       title: 'PRs Awaiting Approval',
       type: 'metric',
       object: 'procurement_request',
@@ -46,6 +47,7 @@ export const SpendAtAGlanceDashboard: Dashboard = {
     },
     {
       id: 'open_pos',
+      dataset: 'procurement_order_metrics', values: ['order_count'],
       title: 'Open Purchase Orders',
       type: 'metric',
       object: 'procurement_order',
@@ -57,6 +59,7 @@ export const SpendAtAGlanceDashboard: Dashboard = {
     },
     {
       id: 'overdue_pos',
+      dataset: 'procurement_order_metrics', values: ['order_count'],
       title: 'Overdue Deliveries',
       type: 'metric',
       object: 'procurement_order',
@@ -71,6 +74,7 @@ export const SpendAtAGlanceDashboard: Dashboard = {
     },
     {
       id: 'open_commitment',
+      dataset: 'procurement_order_metrics', values: ['sum_total_amount'],
       title: 'Open Commitment ($)',
       type: 'metric',
       object: 'procurement_order',
@@ -83,6 +87,7 @@ export const SpendAtAGlanceDashboard: Dashboard = {
     },
     {
       id: 'pending_requests_table',
+      dataset: 'procurement_request_metrics', values: ['request_count'],
       title: 'Requests Awaiting Approval',
       type: 'table',
       object: 'procurement_request',
@@ -97,6 +102,7 @@ export const SpendAtAGlanceDashboard: Dashboard = {
     },
     {
       id: 'open_pos_table',
+      dataset: 'procurement_order_metrics', values: ['order_count'],
       title: 'Open Purchase Orders',
       type: 'table',
       object: 'procurement_order',
@@ -111,6 +117,7 @@ export const SpendAtAGlanceDashboard: Dashboard = {
     },
     {
       id: 'po_value_by_month',
+      dataset: 'procurement_order_metrics', dimensions: ['order_date'], values: ['sum_total_amount'],
       title: 'PO Value by Month (last 12 months)',
       type: 'line',
       object: 'procurement_order',

--- a/packages/procurement/src/data/index.ts
+++ b/packages/procurement/src/data/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Vendor } from '../objects/procurement_vendor.object';
 import { PurchaseRequest } from '../objects/procurement_request.object';
@@ -15,7 +15,7 @@ import { GoodsReceipt } from '../objects/procurement_receipt.object';
  *   • 3 receipts demonstrating 3-way-match rollup
  */
 
-const vendors = defineDataset(Vendor, {
+const vendors = defineSeed(Vendor, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -63,7 +63,7 @@ const vendors = defineDataset(Vendor, {
   ],
 });
 
-const requests = defineDataset(PurchaseRequest, {
+const requests = defineSeed(PurchaseRequest, {
   mode: 'upsert',
   externalId: 'title',
   records: [
@@ -124,7 +124,7 @@ const requests = defineDataset(PurchaseRequest, {
   ],
 });
 
-const orders = defineDataset(PurchaseOrder, {
+const orders = defineSeed(PurchaseOrder, {
   mode: 'upsert',
   externalId: 'po_number',
   records: [
@@ -176,7 +176,7 @@ const orders = defineDataset(PurchaseOrder, {
   ],
 });
 
-const receipts = defineDataset(GoodsReceipt, {
+const receipts = defineSeed(GoodsReceipt, {
   mode: 'upsert',
   externalId: 'receipt_number',
   records: [

--- a/packages/procurement/src/datasets/index.ts
+++ b/packages/procurement/src/datasets/index.ts
@@ -1,0 +1,2 @@
+export { ProcurementRequestDataset } from './procurement_request.dataset.js';
+export { ProcurementOrderDataset } from './procurement_order.dataset.js';

--- a/packages/procurement/src/datasets/procurement_order.dataset.ts
+++ b/packages/procurement/src/datasets/procurement_order.dataset.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for procurement_order. */
+export const ProcurementOrderDataset = defineDataset({
+  name: 'procurement_order_metrics',
+  label: 'procurement_order metrics',
+  object: 'procurement_order',
+  dimensions: [
+    { name: 'order_date', label: 'order_date', field: 'order_date', type: 'date' },
+  ],
+  measures: [
+    { name: 'order_count', label: 'order_count', aggregate: 'count' },
+    { name: 'sum_total_amount', label: 'sum_total_amount', aggregate: 'sum', field: 'total_amount' },
+  ],
+});

--- a/packages/procurement/src/datasets/procurement_request.dataset.ts
+++ b/packages/procurement/src/datasets/procurement_request.dataset.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for procurement_request. */
+export const ProcurementRequestDataset = defineDataset({
+  name: 'procurement_request_metrics',
+  label: 'procurement_request metrics',
+  object: 'procurement_request',
+  dimensions: [],
+  measures: [
+    { name: 'request_count', label: 'request_count', aggregate: 'count' },
+  ],
+});

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -15,17 +15,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/project/src/data/issues.data.ts
+++ b/packages/project/src/data/issues.data.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { Issue } from '../objects/pm_issue.object.js';
 
 /**
@@ -8,14 +8,14 @@ import { Issue } from '../objects/pm_issue.object.js';
  * Current problems requiring resolution.
  * `project` references the parent project by its `name` externalId.
  */
-export const issues = defineDataset(Issue, {
+export const issues = defineSeed(Issue, {
   mode: 'upsert',
   externalId: 'name',
   records: [
     {
       name: 'Login page crashes on Android 12',
       description: 'App crashes when users try to log in on Android 12 devices.',
-      project: { name: 'Mobile App Redesign' },
+      project: 'Mobile App Redesign',
       status: 'in_progress',
       severity: 'high',
       assigned_to: null,
@@ -24,7 +24,7 @@ export const issues = defineDataset(Issue, {
     {
       name: 'API rate limiting too aggressive',
       description: 'Third-party API rate limits are blocking legitimate requests.',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       status: 'open',
       severity: 'medium',
       assigned_to: null,

--- a/packages/project/src/data/milestones.data.ts
+++ b/packages/project/src/data/milestones.data.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Milestone } from '../objects/pm_milestone.object.js';
 
@@ -9,14 +9,14 @@ import { Milestone } from '../objects/pm_milestone.object.js';
  * Mix of completed, upcoming, and at-risk milestones.
  * `project` references the parent project by its `name` externalId.
  */
-export const milestones = defineDataset(Milestone, {
+export const milestones = defineSeed(Milestone, {
   mode: 'upsert',
   externalId: 'name',
   records: [
     // Mobile App Redesign milestones
     {
       name: 'Design System Complete',
-      project: { name: 'Mobile App Redesign' },
+      project: 'Mobile App Redesign',
       status: 'completed',
       planned_date: cel`daysAgo(20)`,
       actual_date: cel`daysAgo(18)`,
@@ -24,7 +24,7 @@ export const milestones = defineDataset(Milestone, {
     },
     {
       name: 'Beta Release',
-      project: { name: 'Mobile App Redesign' },
+      project: 'Mobile App Redesign',
       status: 'in_progress',
       planned_date: cel`daysFromNow(30)`,
       deliverables: 'TestFlight beta with core features',
@@ -32,7 +32,7 @@ export const milestones = defineDataset(Milestone, {
     // ERP System Migration milestones
     {
       name: 'Data Migration Plan Approved',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       status: 'completed',
       planned_date: cel`daysAgo(60)`,
       actual_date: cel`daysAgo(55)`,
@@ -40,7 +40,7 @@ export const milestones = defineDataset(Milestone, {
     },
     {
       name: 'Phase 1 Data Cutover',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       status: 'in_progress',
       planned_date: cel`daysFromNow(10)`,
       deliverables: 'Core financial data migrated',
@@ -48,7 +48,7 @@ export const milestones = defineDataset(Milestone, {
     // AI Chatbot MVP milestones
     {
       name: 'LLM Vendor Selected',
-      project: { name: 'AI Chatbot MVP' },
+      project: 'AI Chatbot MVP',
       status: 'not_started',
       planned_date: cel`daysFromNow(20)`,
       deliverables: 'Signed vendor contract',

--- a/packages/project/src/data/projects.data.ts
+++ b/packages/project/src/data/projects.data.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Project } from '../objects/pm_project.object.js';
 
@@ -11,9 +11,9 @@ import { Project } from '../objects/pm_project.object.js';
  *   • AI Chatbot MVP - planning phase
  *
  * `name` is the externalId — it is also used by milestones / risks / issues /
- * resources to reference their parent project via `{ name: '…' }`.
+ * resources to reference their parent project via `'…'`.
  */
-export const projects = defineDataset(Project, {
+export const projects = defineSeed(Project, {
   mode: 'upsert',
   externalId: 'name',
   records: [

--- a/packages/project/src/data/resources.data.ts
+++ b/packages/project/src/data/resources.data.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Resource } from '../objects/pm_resource.object.js';
 
@@ -12,28 +12,28 @@ import { Resource } from '../objects/pm_resource.object.js';
  * The `role` text field carries the human-readable allocation label instead.
  * `project` references the parent project by its `name` externalId.
  */
-export const resources = defineDataset(Resource, {
+export const resources = defineSeed(Resource, {
   mode: 'upsert',
   externalId: 'role',
   records: [
     // Mobile App Redesign
     {
       role: 'Project Manager — Mobile App Redesign',
-      project: { name: 'Mobile App Redesign' },
+      project: 'Mobile App Redesign',
       allocated_hours_per_week: 20,
       start_date: cel`daysAgo(45)`,
       end_date: cel`daysFromNow(75)`,
     },
     {
       role: 'iOS Developer — Mobile App Redesign',
-      project: { name: 'Mobile App Redesign' },
+      project: 'Mobile App Redesign',
       allocated_hours_per_week: 40,
       start_date: cel`daysAgo(30)`,
       end_date: cel`daysFromNow(75)`,
     },
     {
       role: 'UI Designer — Mobile App Redesign',
-      project: { name: 'Mobile App Redesign' },
+      project: 'Mobile App Redesign',
       allocated_hours_per_week: 32,
       start_date: cel`daysAgo(45)`,
       end_date: cel`daysFromNow(60)`,
@@ -41,28 +41,28 @@ export const resources = defineDataset(Resource, {
     // ERP System Migration
     {
       role: 'Project Manager — ERP System Migration',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       allocated_hours_per_week: 40,
       start_date: cel`daysAgo(90)`,
       end_date: cel`daysFromNow(30)`,
     },
     {
       role: 'SAP Consultant — ERP System Migration',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       allocated_hours_per_week: 40,
       start_date: cel`daysAgo(75)`,
       end_date: cel`daysFromNow(45)`,
     },
     {
       role: 'Data Analyst — ERP System Migration',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       allocated_hours_per_week: 40,
       start_date: cel`daysAgo(60)`,
       end_date: cel`daysFromNow(30)`,
     },
     {
       role: 'QA Engineer — ERP System Migration',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       allocated_hours_per_week: 32,
       start_date: cel`daysAgo(30)`,
       end_date: cel`daysFromNow(30)`,
@@ -70,21 +70,21 @@ export const resources = defineDataset(Resource, {
     // AI Chatbot MVP
     {
       role: 'Project Manager — AI Chatbot MVP',
-      project: { name: 'AI Chatbot MVP' },
+      project: 'AI Chatbot MVP',
       allocated_hours_per_week: 16,
       start_date: cel`daysFromNow(7)`,
       end_date: cel`daysFromNow(97)`,
     },
     {
       role: 'ML Engineer — AI Chatbot MVP',
-      project: { name: 'AI Chatbot MVP' },
+      project: 'AI Chatbot MVP',
       allocated_hours_per_week: 40,
       start_date: cel`daysFromNow(7)`,
       end_date: cel`daysFromNow(97)`,
     },
     {
       role: 'Backend Developer — AI Chatbot MVP',
-      project: { name: 'AI Chatbot MVP' },
+      project: 'AI Chatbot MVP',
       allocated_hours_per_week: 32,
       start_date: cel`daysFromNow(14)`,
       end_date: cel`daysFromNow(97)`,

--- a/packages/project/src/data/risks.data.ts
+++ b/packages/project/src/data/risks.data.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { Risk } from '../objects/pm_risk.object.js';
 
 /**
@@ -8,14 +8,14 @@ import { Risk } from '../objects/pm_risk.object.js';
  * Includes AI-scored risks with mitigation plans.
  * `project` references the parent project by its `name` externalId.
  */
-export const risks = defineDataset(Risk, {
+export const risks = defineSeed(Risk, {
   mode: 'upsert',
   externalId: 'name',
   records: [
     {
       name: 'Backend team overallocation',
       description: 'Backend engineers are split across 3 concurrent projects, risking delays.',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       status: 'mitigating',
       category: 'resource',
       impact: 'high',
@@ -29,7 +29,7 @@ export const risks = defineDataset(Risk, {
     {
       name: 'LLM vendor pricing uncertainty',
       description: 'LLM API costs may exceed budget at scale.',
-      project: { name: 'AI Chatbot MVP' },
+      project: 'AI Chatbot MVP',
       status: 'identified',
       category: 'budget',
       impact: 'medium',
@@ -43,7 +43,7 @@ export const risks = defineDataset(Risk, {
     {
       name: 'Data integrity during migration',
       description: 'Risk of data loss or corruption during ERP cutover.',
-      project: { name: 'ERP System Migration' },
+      project: 'ERP System Migration',
       status: 'assessing',
       category: 'technical',
       impact: 'very_high',

--- a/packages/todo/objectstack.config.ts
+++ b/packages/todo/objectstack.config.ts
@@ -6,6 +6,7 @@ import * as objects from './src/objects/index.js';
 import * as views from './src/views/index.js';
 import * as pages from './src/pages/index.js';
 import * as dashboards from './src/dashboards/index.js';
+import * as datasets from './src/datasets/index.js';
 import * as profiles from './src/profiles/index.js';
 import * as apps from './src/apps/index.js';
 import { TodoTranslations } from './src/translations/index.js';
@@ -32,6 +33,7 @@ export default defineStack({
   views: Object.values(views),
   pages: Object.values(pages),
   dashboards: Object.values(dashboards),
+  datasets: Object.values(datasets),
   permissions: Object.values(profiles),
   apps: Object.values(apps),
   flows: allFlows,

--- a/packages/todo/package.json
+++ b/packages/todo/package.json
@@ -19,17 +19,17 @@
     "test:qa": "node ../../scripts/run-qa.mjs --url http://localhost:4002 --file qa/business-workflow.test.json"
   },
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0",
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/todo/src/dashboards/my_work.dashboard.ts
+++ b/packages/todo/src/dashboards/my_work.dashboard.ts
@@ -29,6 +29,7 @@ export const MyWorkDashboard: Dashboard = {
   widgets: [
     {
       id: 'my_open_tasks',
+      dataset: 'todo_task_metrics', values: ['task_count'],
       title: 'My Open Tasks',
       type: 'metric',
       object: 'todo_task',
@@ -40,6 +41,7 @@ export const MyWorkDashboard: Dashboard = {
     },
     {
       id: 'my_overdue',
+      dataset: 'todo_task_metrics', values: ['task_count'],
       title: 'Overdue',
       type: 'metric',
       object: 'todo_task',
@@ -55,6 +57,7 @@ export const MyWorkDashboard: Dashboard = {
     },
     {
       id: 'done_this_week',
+      dataset: 'todo_task_metrics', values: ['task_count'],
       title: 'Done This Week',
       type: 'metric',
       object: 'todo_task',
@@ -71,6 +74,7 @@ export const MyWorkDashboard: Dashboard = {
     },
     {
       id: 'recent_overdue_list',
+      dataset: 'todo_task_metrics', values: ['task_count'],
       title: 'Overdue Tasks',
       type: 'table',
       object: 'todo_task',
@@ -88,6 +92,7 @@ export const MyWorkDashboard: Dashboard = {
     },
     {
       id: 'throughput_by_week',
+      dataset: 'todo_task_metrics', dimensions: ['completed_at'], values: ['task_count'],
       title: 'My Throughput by Week (last 12 weeks)',
       type: 'line',
       object: 'todo_task',

--- a/packages/todo/src/data/index.ts
+++ b/packages/todo/src/data/index.ts
@@ -1,9 +1,16 @@
 // Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
 
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Task } from '../objects/todo_task.object';
 import { Label } from '../objects/todo_label.object';
+
+// @objectstack 8.0.1: `defineSeed` types lookup/master_detail fields as
+// `string | null` and has no `multiple: true`-aware overload yet, so a
+// multi-value lookup seeded with an array fails typecheck. `multiRef` keeps
+// the array value (correct at runtime) while satisfying the field type.
+const multiRef = (ids: string[]): string => ids as unknown as string;
+
 
 /**
  * Seed data — realistic, business-like task content covering the full
@@ -21,7 +28,7 @@ import { Label } from '../objects/todo_label.object';
  *               – 4 completed within the last 30 days
  */
 
-const labels = defineDataset(Label, {
+const labels = defineSeed(Label, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -36,7 +43,7 @@ const labels = defineDataset(Label, {
   ],
 });
 
-const tasks = defineDataset(Task, {
+const tasks = defineSeed(Task, {
   mode: 'upsert',
   externalId: 'subject',
   records: [
@@ -47,7 +54,7 @@ const tasks = defineDataset(Task, {
       estimate_hours: 4,
       due_date: cel`daysAgo(20)`,
       completed_at: cel`daysAgo(15)`,
-      labels: ['performance'],
+      labels: multiRef(['performance']),
     },
     {
       subject: 'Design new pricing page mockups',
@@ -55,7 +62,7 @@ const tasks = defineDataset(Task, {
       priority: 'high',
       estimate_hours: 12,
       due_date: cel`daysFromNow(7)`,
-      labels: ['feature', 'design'],
+      labels: multiRef(['feature', 'design']),
     },
     {
       subject: 'Fix mobile nav drawer animation',
@@ -63,7 +70,7 @@ const tasks = defineDataset(Task, {
       priority: 'urgent',
       estimate_hours: 3,
       due_date: cel`daysAgo(2)`, // overdue
-      labels: ['bug'],
+      labels: multiRef(['bug']),
     },
     {
       subject: 'Replace hero illustration with brand-refresh artwork',
@@ -71,7 +78,7 @@ const tasks = defineDataset(Task, {
       priority: 'normal',
       estimate_hours: 2,
       due_date: cel`daysFromNow(14)`,
-      labels: ['design'],
+      labels: multiRef(['design']),
     },
     {
       subject: 'Add cookie-consent banner (GDPR)',
@@ -80,7 +87,7 @@ const tasks = defineDataset(Task, {
       estimate_hours: 6,
       due_date: cel`daysAgo(10)`,
       completed_at: cel`daysAgo(8)`,
-      labels: ['security', 'feature'],
+      labels: multiRef(['security', 'feature']),
     },
     {
       subject: 'Implement offline-first task cache',
@@ -88,7 +95,7 @@ const tasks = defineDataset(Task, {
       priority: 'high',
       estimate_hours: 32,
       due_date: cel`daysFromNow(10)`,
-      labels: ['feature'],
+      labels: multiRef(['feature']),
     },
     {
       subject: 'Wire up push notifications',
@@ -96,7 +103,7 @@ const tasks = defineDataset(Task, {
       priority: 'normal',
       estimate_hours: 8,
       due_date: cel`daysFromNow(18)`,
-      labels: ['feature'],
+      labels: multiRef(['feature']),
     },
     {
       subject: 'Crash on cold-start when no network',
@@ -104,7 +111,7 @@ const tasks = defineDataset(Task, {
       priority: 'urgent',
       estimate_hours: 6,
       due_date: cel`daysAgo(1)`, // overdue
-      labels: ['bug'],
+      labels: multiRef(['bug']),
     },
     {
       subject: 'Reproduce biometric prompt bug',
@@ -112,7 +119,7 @@ const tasks = defineDataset(Task, {
       priority: 'high',
       estimate_hours: 4,
       due_date: cel`daysFromNow(3)`,
-      labels: ['bug', 'security'],
+      labels: multiRef(['bug', 'security']),
     },
     {
       subject: 'Localize onboarding flow (de / fr / ja)',
@@ -120,7 +127,7 @@ const tasks = defineDataset(Task, {
       priority: 'normal',
       estimate_hours: 16,
       due_date: cel`daysFromNow(28)`,
-      labels: ['feature'],
+      labels: multiRef(['feature']),
     },
     {
       subject: 'Drop legacy iOS support and bump min SDK',
@@ -128,7 +135,7 @@ const tasks = defineDataset(Task, {
       priority: 'low',
       estimate_hours: 2,
       due_date: cel`daysAgo(7)`,
-      labels: ['chore'],
+      labels: multiRef(['chore']),
     },
     {
       subject: 'Rotate signing keys for service-to-service JWTs',
@@ -136,7 +143,7 @@ const tasks = defineDataset(Task, {
       priority: 'urgent',
       estimate_hours: 4,
       due_date: cel`daysAgo(3)`, // overdue
-      labels: ['security'],
+      labels: multiRef(['security']),
     },
     {
       subject: 'Document rate-limit headers in developer portal',
@@ -144,7 +151,7 @@ const tasks = defineDataset(Task, {
       priority: 'normal',
       estimate_hours: 3,
       due_date: cel`daysFromNow(30)`,
-      labels: ['docs'],
+      labels: multiRef(['docs']),
     },
     {
       subject: 'Investigate p99 latency spike on /v1/search',
@@ -152,7 +159,7 @@ const tasks = defineDataset(Task, {
       priority: 'high',
       estimate_hours: 8,
       due_date: cel`daysFromNow(5)`,
-      labels: ['performance', 'blocked'],
+      labels: multiRef(['performance', 'blocked']),
     },
     {
       subject: 'Decommission v0 endpoints',
@@ -161,7 +168,7 @@ const tasks = defineDataset(Task, {
       estimate_hours: 6,
       due_date: cel`daysAgo(25)`,
       completed_at: cel`daysAgo(22)`,
-      labels: ['chore'],
+      labels: multiRef(['chore']),
     },
     {
       subject: 'Archive Q1 launch assets',
@@ -169,7 +176,7 @@ const tasks = defineDataset(Task, {
       priority: 'low',
       estimate_hours: 1,
       due_date: cel`daysFromNow(14)`,
-      labels: ['chore'],
+      labels: multiRef(['chore']),
     },
   ],
 });

--- a/packages/todo/src/datasets/index.ts
+++ b/packages/todo/src/datasets/index.ts
@@ -1,0 +1,1 @@
+export { TodoTaskDataset } from './todo_task.dataset.js';

--- a/packages/todo/src/datasets/todo_task.dataset.ts
+++ b/packages/todo/src/datasets/todo_task.dataset.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** ADR-0021 semantic dataset for todo_task. */
+export const TodoTaskDataset = defineDataset({
+  name: 'todo_task_metrics',
+  label: 'todo_task metrics',
+  object: 'todo_task',
+  dimensions: [
+    { name: 'completed_at', label: 'completed_at', field: 'completed_at', type: 'date' },
+  ],
+  measures: [
+    { name: 'task_count', label: 'task_count', aggregate: 'count' },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,17 +18,17 @@ importers:
   packages/all:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -40,38 +40,38 @@ importers:
   packages/compliance:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -87,38 +87,38 @@ importers:
   packages/content:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -134,38 +134,38 @@ importers:
   packages/contracts:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -181,38 +181,38 @@ importers:
   packages/expense:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -228,38 +228,38 @@ importers:
   packages/helpdesk:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -275,38 +275,38 @@ importers:
   packages/hr:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -322,38 +322,38 @@ importers:
   packages/procurement:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -369,38 +369,38 @@ importers:
   packages/project:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -416,38 +416,38 @@ importers:
   packages/todo:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.194(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.194(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -775,35 +775,35 @@ packages:
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
-  '@objectstack/account@7.7.0':
-    resolution: {integrity: sha512-zbTAOeP22s6AyTph/FxyEZyU3RNHCJVq6Rb6Fr3R4wtLi0fWFgdLIL1DsODpwQKt3fjbaH49/8HfJDR7Ss20vw==}
+  '@objectstack/account@8.0.1':
+    resolution: {integrity: sha512-hio0SB54+dZJDVkpjU1OZ6Sft3Y1/6gBw0XLZmTqpKxRD6L5Upc/WJ9iL0o55hLvlFKB1d+PotaAtPFK9V6YWg==}
 
-  '@objectstack/cli@7.7.0':
-    resolution: {integrity: sha512-5A7j7z9JRyWl6OZUB5N3cmINI/8DtOvW3MtL9rTa/+4Hq2nYvC4GuKyXG641xTNQPJDraVVYcEhFHn+etry8rA==}
+  '@objectstack/cli@8.0.1':
+    resolution: {integrity: sha512-aMuZHCcLQ3ZB19utH8Rf5lMch9q1LfqMbpBwAawhl79P7QcDR+bX/xMprASM81m2kYhTT+La0dMadM6gkwgjnA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@objectstack/client@7.7.0':
-    resolution: {integrity: sha512-QxFIq99kuAXkkefzlnTM7g3btc4Rj/hzYbaf5PIqfitaoLJNswsa6LJuKoNaMQIdetUWsD3QfyM4iK5gdeJrFQ==}
+  '@objectstack/client@8.0.1':
+    resolution: {integrity: sha512-fLObUYXfa6XmoutgLK5SRthROKM16PTbMyOntiIoGI76zOHbsbZNa8FyDnSV7kEnjWERjBlEedjgT9201Pvnyg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/console@7.7.0':
-    resolution: {integrity: sha512-bG4FZe6mJSpenHAsBYqtQBCDcQcbTTRB66TMdoqVm1fM0546X07OD5cc85CUpt9fRDo7coTSjJpSv4XCKsHg7w==}
+  '@objectstack/console@8.0.1':
+    resolution: {integrity: sha512-d4I0hLRgJKV45MZanPWsCEyXxj7zzZMcjxdIBAc/g+CYWxS8i/dMgi5cuGnQxxPyopmElyadxoFav2tA3kScaA==}
 
-  '@objectstack/core@7.7.0':
-    resolution: {integrity: sha512-HwgkV2QInlT2q5QJQP11DM7/k/WSKvz2T1k78kQKFWB1zp2hhSNVy0C0f0pOPgNcLkShiIEPsFMPY5qV4zq1eA==}
+  '@objectstack/core@8.0.1':
+    resolution: {integrity: sha512-222khmv9KMBCI1dfjy2jknK9kpv/+RD9kcmNCrRApEzRQ5/TbE75UCM+T245yse61K7ez8CV0py/Yr5KJNj6FA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-memory@7.7.0':
-    resolution: {integrity: sha512-xUWXBIs6cTKlFzxSPLw3rpPF+VZ/b7huewWgrImaW27c7sZ39gWtiISlxI+4PdyJIlZFZq+V/rX0/XCn1UYpow==}
+  '@objectstack/driver-memory@8.0.1':
+    resolution: {integrity: sha512-rl3arNAOPotnlRi3PIkcN+597PBUXFdizfijjDOIMbi18KCCaMnFJY+rbk9ASfJv+kfN6L18S2EKSF6CnYoA6w==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-mongodb@7.7.0':
-    resolution: {integrity: sha512-8A31jNpRLahzWlassIi77y/6tQdO0k6ktU7qz2/T7cXnk1uWin/3sH4zvG5p/bb3m9VEhq3vF4AeQOpNnTEXXQ==}
+  '@objectstack/driver-mongodb@8.0.1':
+    resolution: {integrity: sha512-+qdeMt2gYT2NUO7WzoFYbZMvOLjy6n9N7Cs0QRGHFyNOAR9HRlGe/V97dpsmzDAiRDRXDsqdM3Z/shrEJykxZg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-sql@7.7.0':
-    resolution: {integrity: sha512-UPe0YgfYQyKe9wM9eugCmKFx3J3BDJxQLq/NLqsW+aoJeBtpQ4eG926uMm0MlZIq/XAVJtzKBJ6s5IHXSki53g==}
+  '@objectstack/driver-sql@8.0.1':
+    resolution: {integrity: sha512-2kT8VSqDQK1P1hQ2P84FE38fLrD75O9VxZZdLr20IfJI/kUn+klx0KLiu7dGCog7nDic3iSIxamsfxxh3fbSAA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       mysql2: ^3.0.0
@@ -820,15 +820,19 @@ packages:
       tedious:
         optional: true
 
-  '@objectstack/driver-sqlite-wasm@7.7.0':
-    resolution: {integrity: sha512-TOoXwt3mQnRfaBoNywgA5AEijJDb9a1WXxBiWHqFe3ZZ1vC91A9NkbtxWoNnewI2EeOQeNEwHGtm6UjHwYnWiQ==}
+  '@objectstack/driver-sqlite-wasm@8.0.1':
+    resolution: {integrity: sha512-C0bFYRRRyJJB5nJNCoreLWINf4qVEMaZivnioKFkex2Ycb3uwydFedyV7JwAertTjFXXoFaSI54KAXMV+4/Qfg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/formula@7.7.0':
-    resolution: {integrity: sha512-N0ZWFMYmEyz1wgY9FAcsAtYLOSmtvAOn0sxr1hU2SIpK6ZeSr5IZyLn7Pss+mpRLC3lPAiF5SsgutxCEixoy3A==}
+  '@objectstack/formula@8.0.1':
+    resolution: {integrity: sha512-e/CfchRGxnJW4JB1sDAaNKCAj0kbM83fSpzDmn3UMppG89aW9gSyMiB9TvaOnB35iOxsyhTeZ8R9E/rwEEfmfg==}
 
-  '@objectstack/metadata-core@7.7.0':
-    resolution: {integrity: sha512-W4a1Fm98KGPVsCuJtorlAZd7DkXSKh3Gqeb4+2/JdZFuQVQbJ3bJwtI3V3yxqUfGDBu7iwRzPemdgh08R8Mc+g==}
+  '@objectstack/mcp@8.0.1':
+    resolution: {integrity: sha512-KjJftJySVYvC0E4545iCDXgQLAo0FoxEQbXrXNpy1Yp5DtAYsEZESQodkqy0EJppxmtnXAqLD31k1fgjJUESjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@objectstack/metadata-core@8.0.1':
+    resolution: {integrity: sha512-VWrtvYm1pFoYXR2szmFXshNP6LSJ9sXiQPXtoOuKdZ6092Lt1wnSRrKR5RH5TpSaavXEdsidBffGI4NPp2Ej9A==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       vitest: ^4.0.0
@@ -836,83 +840,79 @@ packages:
       vitest:
         optional: true
 
-  '@objectstack/metadata-fs@7.7.0':
-    resolution: {integrity: sha512-AbwNa8aiaoy5uOIIEN3EbXaJT2V62dQ4m4fvpGLhXhPEJQo9YF/kb/AC0rc2tEDOgBKOi1RPoB3MVxC5Yy2IjQ==}
+  '@objectstack/metadata-fs@8.0.1':
+    resolution: {integrity: sha512-SdVofg5Bj21U5ZkCwSuHAAMjQqtto5SXZNnSrxzvJfh5Cq3AwG2d3RbWaJ+ev/dZeRJG5yuHiEhpdQJP+eOHGw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/metadata@7.7.0':
-    resolution: {integrity: sha512-mxhia9yLgZV/lzPaqnF4fVU1K2QSXHmYWxaJ+XcGiKgsVMlv9eHsK+pwLTxhyhYGV05YBeQzsPFMCbiHML8l3w==}
+  '@objectstack/metadata@8.0.1':
+    resolution: {integrity: sha512-wR6xSJbpSEDPRNMSBbLUyi+NtWsa0TVttgNJrZHqkb1+yLDGUc4K9NT0Et59nVqvVj5AjuC00Mk5uwzLxcxhPA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/objectql@7.7.0':
-    resolution: {integrity: sha512-k+Lx/iN+pKgYkHNy1hIMXu8ByNBaIUK22TW6HblkvFvBm6SlOiXLlV5SIF3AX7V+Dv3t8VPTTdWMWFXDkL2CZw==}
+  '@objectstack/objectql@8.0.1':
+    resolution: {integrity: sha512-c/n6OLYxC6rfipQjyVXy51u/N7wnWYp9hyllfv6kmujwK56yWKkY8iycAqboyCErgmPahuqW1LLdHjE1gmUiGw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/observability@7.7.0':
-    resolution: {integrity: sha512-WEb1YmQTqUhFlpomKi2Rxf4Eq4kYXrDQomENot86M9A0copywRldUl4A38SKbpNaH4bfjmcUbWuivEJGsUR9PA==}
+  '@objectstack/observability@8.0.1':
+    resolution: {integrity: sha512-XwUu5ZzcbJ+AwQ9Nyw17KfIq+WWsIBgAfqrTaTlqEB4tGHXUHEwGIgYcLS9eGDwS9H92ZhrTOY4kh9n7CdLhDg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/platform-objects@7.7.0':
-    resolution: {integrity: sha512-6nv6teqNVGNp+Tzd3YzLW+oBfK+bFUXGjU/A81qxqVB+HStTn4wqDULenhCNc6BMnw0QB9EEvOX4Ezqnv9xf/w==}
+  '@objectstack/platform-objects@8.0.1':
+    resolution: {integrity: sha512-3qOTeedtN78oyA4Oe/G21Lrf/H8nKa0oGsb8VoscS0nwdKmqRG4vlKplv998voEqro1HwIjvf5KZvQ1HBomVKw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-approvals@7.7.0':
-    resolution: {integrity: sha512-ktrxF+2Plohb+98cQB8WD2YjmtdCpP+ny9aaeqZqU6q6WZFhSj/1psFKfc6p4qWqnTYIhE6Ia3lf8ulZOyK4FA==}
+  '@objectstack/plugin-approvals@8.0.1':
+    resolution: {integrity: sha512-PCrqaTeEgQK+kDfEx4PUsaba9u9Ry/HFPrsx1xWkNS1sglfJG+LFqQEPHxUCDXIlap7hcj6gQtXJl42vVgZnPg==}
 
-  '@objectstack/plugin-audit@7.7.0':
-    resolution: {integrity: sha512-wigjWTNQz0lpK2mEg8ohcMBTJ25EGjOOMnk0BfsBRPRTnXtjPOd6Mhi+XY1IfVa6l20+9/oqJ3PbyBq93Qn2FQ==}
+  '@objectstack/plugin-audit@8.0.1':
+    resolution: {integrity: sha512-VqeC1xnLz1SPVo6+jOnPiWgJaiOPdXipyS6leS/wIVO6h+BcHR4e9XnQefYlB+ikVUeZwl6WM2iVHE48IatNuQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-auth@7.7.0':
-    resolution: {integrity: sha512-6dxO8XpIUuCD3cvu0tRQW5Vj6il72O6VHB1HZW6CG7rG9oALacUFNDlJcqSiZGtORgZbQDt8Np3d8foc6qhqBA==}
+  '@objectstack/plugin-auth@8.0.1':
+    resolution: {integrity: sha512-nLk3/lentF5qZ72X0c/fC5b8Ne/COg6dgwgUUscN8QQIR3EvHPsSWAeLOsrBVqb74v/ShxE81GkbxC0pK81fOQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-email@7.7.0':
-    resolution: {integrity: sha512-P3mN8T5CeM/pzaXRX1S3eaMIaY+ZcxgtcFtey2xo7i+++Kj+XpG+TNnBEAR0Zv46g5ITyX9rMp/nLD49ED6nsg==}
+  '@objectstack/plugin-email@8.0.1':
+    resolution: {integrity: sha512-psYJmJDp3LCYWCOk8b1ygVbjcYfYw+BVDeXAEl0LvkMPrPa/ugxAIcDINPSmZluTdL1BjionOSb/ohboHr/g+Q==}
 
-  '@objectstack/plugin-hono-server@7.7.0':
-    resolution: {integrity: sha512-pL14ZqDL4WS/MjJrc49PW2ygUsQozk6ccWV//9vgS7kwEbk2aPKWy58JD6lWIBduz0gWnDoT0IDH0TYMidbhMA==}
+  '@objectstack/plugin-hono-server@8.0.1':
+    resolution: {integrity: sha512-l2RKsunYIzxIU9emWxGVDOonoDDItiE/PDEA0qoBwUG2jUH4pkEahIaUKVgri9NZetKtp9ulKnHTHcDlzqpe7g==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-mcp-server@7.7.0':
-    resolution: {integrity: sha512-0lvHrFU/R5hZHd4fTbaVxTjmjtyKZ2tp/AF4MbgxZJAsU2Thf+cBnz3lHBbtpxGUdH2vsvTKqUuJoL95MK/3jQ==}
+  '@objectstack/plugin-org-scoping@8.0.1':
+    resolution: {integrity: sha512-PrrOzZbwW61AiPvDylSsSduR8Fi19l1pRjKk4e4VMSoJUiM9H+mdYxVtiANT+rpdEUxmjCl4tA1uv5WrGbkksA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-org-scoping@7.7.0':
-    resolution: {integrity: sha512-vxopncbwSI1jnmX1Hsde3tHKuL8hsCHbfZjXjILpAQPGdHmddE3CMwaE3yNFq07WmbIFf4o2kEaXphuECgN15A==}
+  '@objectstack/plugin-reports@8.0.1':
+    resolution: {integrity: sha512-500DjcpmmjtmvOUsrfwK+faGshBfoRAaXdfxzEjwHoFZfXTBX1Uc12YoTySoxQyuXoXE3Lw9OBARAyYiELss8Q==}
+
+  '@objectstack/plugin-security@8.0.1':
+    resolution: {integrity: sha512-NaEozXRvGH06UhFz2CVoKq8YoPc5OTTeoMk3IQ+kiUMz1w0Ky4dwTkXJzd9zW9aWL8cMQ9ezpC1oNQBVcaMo4Q==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-reports@7.7.0':
-    resolution: {integrity: sha512-0P33m1jmG3+NMmbIMuk2fJA8+qkNnwYDj3QFKmVvEVO5rApP7wfAUxL8H7qx10jAL9Fkr13I4GMggNfjbblcNg==}
+  '@objectstack/plugin-sharing@8.0.1':
+    resolution: {integrity: sha512-7vpjAG1uV0cgcxhnEB05WyjGhwlYT7ezufo+83ya9kxJdORnyo8wPHsQ5bnuntOdz0aTtn5WTvS4nQVlZoxkaw==}
 
-  '@objectstack/plugin-security@7.7.0':
-    resolution: {integrity: sha512-NnnsFrbxFp8xAECkKjIkUzKHsrjWWIVWTJrn+xAYzk17ToTjU47qBDdfRZdv+36B7WPLt4jwAz2sVg3IzPdpzg==}
+  '@objectstack/plugin-trigger-record-change@8.0.1':
+    resolution: {integrity: sha512-dvedWALQ78q6cqfwVskZmwcml4f7FsifgqYosNkQWVDW4yE+6em4Gro3ert8XmMBQomFl85SttHf6VdiOiZoYg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-sharing@7.7.0':
-    resolution: {integrity: sha512-KNmaWZ/q9c4gFGSRqFAX7A5pdt5jTnc9+LdvJy/ONndCeIJI8dZXX3zlvZlifkqJt2zbRwO1uQ8e+72y7UZKWA==}
-
-  '@objectstack/plugin-trigger-record-change@7.7.0':
-    resolution: {integrity: sha512-Ds8W3z+cLFpKeWXA4jvB8y3KV8yiSRP8K2L22SPNpAanjIDn2LkwblTQDEZwl1kRXAYa3SQ3kWWCeFDqN2WoHQ==}
+  '@objectstack/plugin-trigger-schedule@8.0.1':
+    resolution: {integrity: sha512-xMiICt1+v/afoTZ8hy/e1Wyi2NEYFQkLxtqxMC72AtIYT6caHJFJLAvzn15Y1nQeMs4tQAJh8t23n1+6hZ8cxQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-trigger-schedule@7.7.0':
-    resolution: {integrity: sha512-z+Rrty6FVn+bOSbqW9Es1hEPTr8MzG1yBb6dRyaXqRUaitIurmsVAOfX+IYBSx72pvBG3lmXkzeW7J4nOuv8gQ==}
+  '@objectstack/plugin-webhooks@8.0.1':
+    resolution: {integrity: sha512-UMzvj2UDm2wJcKQ4yCdOnWxQj/rL/rni90ZkDFwJaVqdstRWmNE/gVUssPvPKTNuA2HxC4+rQdIUfXRQMZvmtQ==}
+
+  '@objectstack/rest@8.0.1':
+    resolution: {integrity: sha512-YA05taXQs3Rzz/DHlF5XBb9BKcmevDHhSA+YmXX8gTIwsuxWQgYG1YyrnWAPBNByyTwCHXqaT/bcBOE0IZ2Wlg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-webhooks@7.7.0':
-    resolution: {integrity: sha512-DZCN5PgX6hOb0TCjYKBc4IfrX75/7cBFZG/xXEwxDX0el5pIvkR7IZK27LJwtD8ZXd6DpvXu4lS/qBUAwi8bpw==}
-
-  '@objectstack/rest@7.7.0':
-    resolution: {integrity: sha512-wN5vmXhyPRavDb4LfxUFMU7Lgh1LPuk6rekLnNg7Eds5eVsVKio2eAtxzIErH8BOntlDKEvsVJv73cSFnapZ6g==}
+  '@objectstack/runtime@8.0.1':
+    resolution: {integrity: sha512-fY5DtKCexgM5AjQnd363wamvLPS88SrDeK7mF84YDoVksD7JmCyeoMzeLQAGm3kOj3dX2F5uEE39m64pUeL+4w==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/runtime@7.7.0':
-    resolution: {integrity: sha512-vzcwZoBC+EyXu2n9IU8sAnGrvtjlW9AuhUWZ9yjLz20Og1AZ8oVXv2aPJGwZXkOehz/ct3b28qn/eY/SEbWmwA==}
-    engines: {node: '>=18.0.0'}
-
-  '@objectstack/service-ai@7.7.0':
-    resolution: {integrity: sha512-i44xxXNx9LE7SfyUS3UOnlpyLSj2yKQUwyOY2wnNwNErjapfkQ0SmlGUNTnhFTRDlM0we33lHovdJJb1QnLNuA==}
+  '@objectstack/service-ai@8.0.1':
+    resolution: {integrity: sha512-i1dj3BV8O/C8ENFDmEzEgIQ7iVt7WPetmRUz5JRYFM+ubeErVwaJAm1JAn/HJ6SRQl7i7fO+fgjWSLvlUr6THA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@ai-sdk/anthropic': ^3.0.0
@@ -929,58 +929,58 @@ packages:
       '@ai-sdk/openai':
         optional: true
 
-  '@objectstack/service-analytics@7.7.0':
-    resolution: {integrity: sha512-8vH7T7BuVyRp7QPc9thMlEYfdIMIQpasH5NzBVR079vOOcFoZfHzIKvQONUgEBB3bCM6Zl6+p86kMdEWAfL07Q==}
+  '@objectstack/service-analytics@8.0.1':
+    resolution: {integrity: sha512-3DWT/kmeM/U4wOzrk2yO1vyrlkij8KLhQIuhbDCth+Xwwj94U4YaPs8JbdmfsSEfec+D5YGnfGaagdk0Q87ejw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-automation@7.7.0':
-    resolution: {integrity: sha512-MdW1o2A40UUzZTCG5+XVbTbY7jCViNRPo5lgSYzIVMbfklhQjEYQNIHU2WlP1HgbOlf78NyVUl+lpyscX+tSzg==}
+  '@objectstack/service-automation@8.0.1':
+    resolution: {integrity: sha512-eiZQH/FGh5Mj1I5EYtn8FGRibWTusM9+SbiE90F02BJ4CSC56PlJ5lXJofyktme+EQf+yQsS/Ck30fAkMZpXYg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-cache@7.7.0':
-    resolution: {integrity: sha512-0TBJ5yCGBpsWCOOnmJbWoefSJsXWicl4YVxKouC4bolbYJLMWlCH7D3ZoI2f4zQvb/uguIx2p/+rrSsfT6SR/Q==}
+  '@objectstack/service-cache@8.0.1':
+    resolution: {integrity: sha512-ZZzseZzvflsa2NyC1JUvGUVbq/BYBdQpop3jqZ4W7lqquueiHkN3ffbHGnSf7HJL++/fkwMKKZiDahSecCg7kA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-cluster@7.7.0':
-    resolution: {integrity: sha512-H9RBrgmnMVHZYZI9KKAQdChEAlTIpZh7IiQN1LydouQibZw1k7FveuMyzwhV384gq/VueE03jEgQVZddiAeqDw==}
+  '@objectstack/service-cluster@8.0.1':
+    resolution: {integrity: sha512-FR8cHaM/45Ez9VICsp8B1KtwBNlyotqmuazgnT7vJ7FySMRyGKjcWw03Ua8pgYQFYwSpKOl73esgljBCeOuAXw==}
 
-  '@objectstack/service-datasource@7.7.0':
-    resolution: {integrity: sha512-oenatd7hSIXH3Zgd/AoZN/916pWjsZkHSdrsMOWCxqEUmueKXPorctn1Y62liXN3zI91bHJBIP4Wkc9BdoA3LA==}
+  '@objectstack/service-datasource@8.0.1':
+    resolution: {integrity: sha512-kKR0m3YlUw9/Kk4YfjLWqixKYLg5an0G/yNIJxBSrTSAz/9c9XNzfyon5QWvhJg5EPoY/01VKvlGxbcqh1guVA==}
 
-  '@objectstack/service-feed@7.7.0':
-    resolution: {integrity: sha512-G9TEwyTscCDY7qS/3HBEXpFqLxEdri4zIwk6gLdpLw7hQsWEMmZBn8CzAo2IEsGukFi/z9MTkXvF3bwT7kx/pw==}
+  '@objectstack/service-feed@8.0.1':
+    resolution: {integrity: sha512-nGIxnV5qXpp9dL7njuTXq/TA2dAZMFddAcRHhdH9q8qyVdO2DcOi8n4MSaaqdALUnNbwTCLImEuhVTxF+Yo15A==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-i18n@7.7.0':
-    resolution: {integrity: sha512-JYa1EEivpkPOCG6ReKDFZeKkzJkgoXayKHnmcjDBtJSRMVWvgdftq4WoKsWiFsTcG4mkkFktzTrmCq22lZEY5w==}
+  '@objectstack/service-i18n@8.0.1':
+    resolution: {integrity: sha512-h1YjPxHURiLyIc3Mf7dOJ1pgVtnkHxh3ppWuW650pXYo4F4Ys5gbsNNxUD1fuJhGQiQaycBPfADw/0BdK+wv+Q==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-job@7.7.0':
-    resolution: {integrity: sha512-tErPzkcawnpzSubp2PB3mQN8MeA3CV5nGIw8Yy/vLl2cQBBkfI9Gq5rQTBMwfEFUhUuy+6QV1ys04M2GutT88A==}
+  '@objectstack/service-job@8.0.1':
+    resolution: {integrity: sha512-KlTBzR/RL8yIMp4qxpkaoZYYsktAedq1GbgNxTDCWL9wbRGL7S0GNvvG1/dPbg71jgDNIzYUdFjfWCwj5upHkg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-messaging@7.7.0':
-    resolution: {integrity: sha512-Zufrs7SdXPQ0DlA8Mhfr3e+T8isy0w4jk4wdyWNoucqCRTXn0hLoKYp5ovfjpcjoZlCiG7pF8aUJ0Ldpr76uMA==}
+  '@objectstack/service-messaging@8.0.1':
+    resolution: {integrity: sha512-k3q4RyxOEy3U0NxYfVCGcQsi2cNXsvqjNrvUMrMh9Fuew6WHOeuUJ3ftChfOR8EzYHdT/OH/8VYzQjxmKVxNwQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-package@7.7.0':
-    resolution: {integrity: sha512-eENxVcH3pGmLFQQgqPYY6DWwwwX1O6BZZOhzlMlSMhc4ka4lUE0W5JOkrXjagIJckKf3ul6f5DguVLT5wn9N8g==}
+  '@objectstack/service-package@8.0.1':
+    resolution: {integrity: sha512-hTxON2MnrFAHDRNKXYudG0qoSOYbTvpYG7qeo19NnT+lWvvMGcL/9v02SQzjIWZEaV+wsubF0bArdaD2qI5vyQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-queue@7.7.0':
-    resolution: {integrity: sha512-Ekf3IX/t0LUz690mMXQufnHazoxeBrqSNkuRvWWtRn3rzhBg1Uxjl9P/CJiP2JwIR4KotmYScJP9mGftw1TDZg==}
+  '@objectstack/service-queue@8.0.1':
+    resolution: {integrity: sha512-WoOvd+3IQODws99OIwIXQ4armhW0N7JiRQG8Vip6y6s+OFQkZgB5/IG7xtxPHQAAgfmdSDKsNvteeZd2MTK5kg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-realtime@7.7.0':
-    resolution: {integrity: sha512-q/wrSVB5NhSZSIToE7TvFqkHPUtwfMSEHS0E475UButbRLRu/EzgfQ7CPFO/APv9zetjQJmF/hNaKrrcQZmkog==}
+  '@objectstack/service-realtime@8.0.1':
+    resolution: {integrity: sha512-btZGq/ap0Gzl7Ftd886XgMbLclqTbIuAi4B1g1mpAQja8fHQahRiYo/5UW6UXiWlSf4mKOidRrWpmQpjACVR4A==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-settings@7.7.0':
-    resolution: {integrity: sha512-9F21JIjEjrK0RbHn3QFSaI9dZbR9fE678HjJHm287d4ARPog0aLT1LoSuH7x3eZLGzEWwMt4xZHoGImaj0MYYg==}
+  '@objectstack/service-settings@8.0.1':
+    resolution: {integrity: sha512-/Kco/IfvdeMzioPP7UrkqTTVHatrtoHDr2R0VTDvC7jMV2HZORqdFgBWGVmLdY9xUF59I1OP/FxgwtfoT6ixAg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-storage@7.7.0':
-    resolution: {integrity: sha512-KCNbp4DmeudFb/eTbnqxmvopfzPwYatRe0pOZqDVnwXjPU3C/UNLu3Si6XNu9f7T8tm6gJztp9ofFCfGYpctPw==}
+  '@objectstack/service-storage@8.0.1':
+    resolution: {integrity: sha512-SOnvpditPPf4AdaqKCXHPxqQXGw0k3UD67RDTHouk2N+JKoa+Sx0osS0TzhkhrVwha4Kxdvu0M+tyWh0DAGbcA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@aws-sdk/client-s3': ^3.0.0
@@ -991,8 +991,8 @@ packages:
       '@aws-sdk/s3-request-presigner':
         optional: true
 
-  '@objectstack/spec@7.7.0':
-    resolution: {integrity: sha512-p9GxtbD8oJFkf9tjNlaOZmBxufskk683IhBL0My8NK0EOH/xG1xbbeAWctpHHIdK91hz9EkZLthtJVbnBNaMPw==}
+  '@objectstack/spec@8.0.1':
+    resolution: {integrity: sha512-ZTHxY0TJIGDGNNd+i5Jzl8KQEA4wxgm46WTICrrYEybdsUnSkuOEKSW3lH0IBB8vI9Dx8/yUtKw77Di9NDfkAw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       ai: ^6.0.0
@@ -1000,8 +1000,8 @@ packages:
       ai:
         optional: true
 
-  '@objectstack/types@7.7.0':
-    resolution: {integrity: sha512-msQcyAmD1cFB4KQ3EH9brnoqBIXMTwwmSAagtbJqCBj7bFLKmtAXdjWHp+6FQFG5lHDBwldA0aRO5DEvdzOZaA==}
+  '@objectstack/types@8.0.1':
+    resolution: {integrity: sha512-1oA7/z2k9UkdopRCmEHLVj5bpQJxBZt3qBI8TxN81LhDzTBibI4Bl5qBJiUPc7ClNQuCQHrUjRD/NTadSkq7Dw==}
     engines: {node: '>=18.0.0'}
 
   '@oclif/core@4.11.4':
@@ -2262,53 +2262,53 @@ snapshots:
 
   '@noble/hashes@2.2.0': {}
 
-  '@objectstack/account@7.7.0': {}
+  '@objectstack/account@8.0.1': {}
 
-  '@objectstack/cli@7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@objectstack/cli@8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@ai-sdk/gateway': 3.0.122(zod@4.4.3)
-      '@objectstack/account': 7.7.0
-      '@objectstack/client': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/console': 7.7.0
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-memory': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-mongodb': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-sql': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-sqlite-wasm': 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
-      '@objectstack/formula': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/objectql': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/observability': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-approvals': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-audit': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-auth': 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@objectstack/plugin-email': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-hono-server': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-mcp-server': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-org-scoping': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-reports': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-security': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-sharing': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-trigger-record-change': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-trigger-schedule': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-webhooks': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/rest': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/runtime': 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@objectstack/service-ai': 7.7.0(@ai-sdk/gateway@3.0.122(zod@4.4.3))
-      '@objectstack/service-analytics': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-automation': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-cache': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-datasource': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-feed': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-job': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-messaging': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-package': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-queue': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-realtime': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-settings': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-storage': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/account': 8.0.1
+      '@objectstack/client': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/console': 8.0.1
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-memory': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-mongodb': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-sql': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-sqlite-wasm': 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+      '@objectstack/formula': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/mcp': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/objectql': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-approvals': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-audit': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-auth': 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/plugin-email': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-hono-server': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-org-scoping': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-reports': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-security': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-sharing': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-trigger-record-change': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-trigger-schedule': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-webhooks': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/rest': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/runtime': 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/service-ai': 8.0.1(@ai-sdk/gateway@3.0.122(zod@4.4.3))
+      '@objectstack/service-analytics': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-automation': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-cache': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-datasource': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-feed': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-job': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-messaging': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-package': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-queue': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-realtime': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-settings': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-storage': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       '@oclif/core': 4.11.4
       bundle-require: 5.1.0(esbuild@0.28.0)
       chalk: 5.6.2
@@ -2368,34 +2368,34 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/client@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/client@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/console@7.7.0': {}
+  '@objectstack/console@8.0.1': {}
 
-  '@objectstack/core@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/core@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-memory@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/driver-memory@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       mingo: 7.2.1
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-mongodb@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/driver-mongodb@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       mongodb: 7.2.0
       nanoid: 5.1.11
     transitivePeerDependencies:
@@ -2408,10 +2408,10 @@ snapshots:
       - snappy
       - socks
 
-  '@objectstack/driver-sql@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/driver-sql@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       knex: 3.2.10(better-sqlite3@12.10.0)
       nanoid: 5.1.11
     optionalDependencies:
@@ -2423,11 +2423,11 @@ snapshots:
       - pg-query-stream
       - supports-color
 
-  '@objectstack/driver-sqlite-wasm@7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)':
+  '@objectstack/driver-sqlite-wasm@8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-sql': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-sql': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       knex: 3.2.10(better-sqlite3@12.10.0)
       nanoid: 5.1.11
       sql.js: 1.14.1
@@ -2443,36 +2443,48 @@ snapshots:
       - supports-color
       - tedious
 
-  '@objectstack/formula@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/formula@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
       '@marcbachmann/cel-js': 7.6.1
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/metadata-core@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/mcp@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - ai
+      - supports-color
+
+  '@objectstack/metadata-core@8.0.1(ai@6.0.194(zod@4.4.3))':
+    dependencies:
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/metadata-fs@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/metadata-fs@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.194(zod@4.4.3))
       chokidar: 5.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/metadata@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/metadata@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/metadata-fs': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata-fs': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       chokidar: 5.0.0
       glob: 13.0.6
       js-yaml: 4.2.0
@@ -2481,62 +2493,62 @@ snapshots:
       - ai
       - vitest
 
-  '@objectstack/objectql@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/objectql@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/formula': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       ajv: 8.20.0
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/observability@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/observability@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/platform-objects@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/platform-objects@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-    transitivePeerDependencies:
-      - ai
-      - vitest
-
-  '@objectstack/plugin-approvals@7.7.0(ai@6.0.194(zod@4.4.3))':
-    dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/formula': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-audit@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-approvals@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-auth@7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@objectstack/plugin-audit@8.0.1(ai@6.0.194(zod@4.4.3))':
+    dependencies:
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+    transitivePeerDependencies:
+      - ai
+      - vitest
+
+  '@objectstack/plugin-auth@8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@better-auth/core': 1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/oauth-provider': 1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-auth@1.6.13(@opentelemetry/api@1.9.1)(better-sqlite3@12.10.0)(mongodb@7.2.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(better-call@1.3.5(zod@4.4.3))
       '@noble/hashes': 2.2.0
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       better-auth: 1.6.13(@opentelemetry/api@1.9.1)(better-sqlite3@12.10.0)(mongodb@7.2.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@better-auth/utils'
@@ -2568,127 +2580,115 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/plugin-email@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-email@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-hono-server@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-hono-server@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
       '@hono/node-server': 2.0.4(hono@4.12.23)
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       hono: 4.12.23
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-mcp-server@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-org-scoping@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - ai
-      - supports-color
-
-  '@objectstack/plugin-org-scoping@7.7.0(ai@6.0.194(zod@4.4.3))':
-    dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-reports@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-reports@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-security@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-security@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-sharing@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-sharing@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/objectql': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/objectql': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-trigger-record-change@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-trigger-record-change@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-trigger-schedule@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-trigger-schedule@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-webhooks@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/plugin-webhooks@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-messaging': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-messaging': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/rest@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/rest@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-package': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-package': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/runtime@7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@objectstack/runtime@8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-memory': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-sql': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/driver-sqlite-wasm': 7.7.0(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
-      '@objectstack/formula': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/metadata': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/objectql': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/observability': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-auth': 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@objectstack/plugin-org-scoping': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/plugin-security': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/rest': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-cluster': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/service-i18n': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-memory': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-sql': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-sqlite-wasm': 8.0.1(ai@6.0.194(zod@4.4.3))(better-sqlite3@12.10.0)
+      '@objectstack/formula': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/metadata': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/objectql': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-auth': 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.194(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/plugin-org-scoping': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/plugin-security': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/rest': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-cluster': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/service-i18n': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       quickjs-emscripten: 0.32.0
       zod: 4.4.3
     optionalDependencies:
-      '@objectstack/driver-mongodb': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/driver-mongodb': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@better-auth/utils'
@@ -2732,139 +2732,139 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/service-ai@7.7.0(@ai-sdk/gateway@3.0.122(zod@4.4.3))':
+  '@objectstack/service-ai@8.0.1(@ai-sdk/gateway@3.0.122(zod@4.4.3))':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/formula': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
       ai: 6.0.194(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       '@ai-sdk/gateway': 3.0.122(zod@4.4.3)
 
-  '@objectstack/service-analytics@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-analytics@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-automation@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-automation@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/formula': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cache@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-cache@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/observability': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cluster@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-cluster@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-datasource@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-datasource@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-feed@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-feed@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-i18n@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-i18n@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-job@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-job@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
       croner: 10.0.1
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-messaging@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-messaging@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-package@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-package@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-queue@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-queue@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-    transitivePeerDependencies:
-      - ai
-      - vitest
-
-  '@objectstack/service-realtime@7.7.0(ai@6.0.194(zod@4.4.3))':
-    dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-settings@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-realtime@8.0.1(ai@6.0.194(zod@4.4.3))':
+    dependencies:
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+    transitivePeerDependencies:
+      - ai
+      - vitest
+
+  '@objectstack/service-settings@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
       '@noble/ciphers': 2.2.0
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-storage@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/service-storage@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/observability': 7.7.0(ai@6.0.194(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/spec@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/spec@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
       zod: 4.4.3
     optionalDependencies:
       ai: 6.0.194(zod@4.4.3)
 
-  '@objectstack/types@7.7.0(ai@6.0.194(zod@4.4.3))':
+  '@objectstack/types@8.0.1(ai@6.0.194(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.7.0(ai@6.0.194(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.194(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,12 @@
 packages:
   - 'packages/*'
+allowBuilds:
+  better-sqlite3: set this to true or false
+  esbuild: set this to true or false
+# pnpm 10 no longer reads `pnpm.onlyBuiltDependencies` from package.json — it
+# must live here. These deps have native/postinstall build steps.
+onlyBuiltDependencies:
+  - better-sqlite3
+  - esbuild
+  - sharp
+  - msw


### PR DESCRIPTION
## What

Migrate every dashboard widget across all 8 template apps (helpdesk, todo, compliance, contracts, expense, hr, procurement, content — **11 dashboards, ~81 widgets**) to the semantic `dataset` form (ADR-0021), side-by-side with the legacy inline query (additive **dual-form**).

- Adds **~18 per-object datasets** (`<object>_metrics`) declaring count/sum/avg measures + categorical/date dimensions.
- Each widget gains `dataset` + `dimensions` + `values` bindings.
- Fixes `packages/all/scripts/compile-marketplace.mjs` to compose the `datasets` slot (it was dropped, so the `all` suite registered dataset-bound dashboards but not the datasets → queries 404'd).

## Verification

- Full workspace **typecheck: 0 errors**; **build: all 9 packages**.
- **Server-side, in-browser** (ran the `all` suite, dataset queries vs raw-DB recompute): **18 datasets register; ~72 dataset widgets return DB-correct numbers (0 mismatch)**; ~10 date-bucketed trend widgets skipped (need timeDimension). KPIs (count/sum/avg) and grouped charts all match.

## Depends on (UI rendering)

The dual-form is **server-side correct**, but the **published console** has two `DatasetWidget` rendering bugs that this migration surfaces — both fixed in **objectui PR #1612**:
1. widget `filter` dropped → filtered widgets show the unfiltered total;
2. legacy string `compareTo` → 500 (`compareTo requires a timeDimension`).

Until that console fix ships, dataset-bound widgets with a `filter`/`compareTo` won't render correctly in the UI (the legacy inline form still renders fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)