### PR TITLE
style: apply prettier formatting to restore green CI

### DIFF
--- a/packages/compliance/src/dashboards/control_posture.dashboard.ts
+++ b/packages/compliance/src/dashboards/control_posture.dashboard.ts
@@ -41,7 +41,8 @@ export const ControlPostureDashboard: Dashboard = {
   widgets: [
     {
       id: 'passing_controls',
-      dataset: 'compliance_control_metrics', values: ['control_count'],
+      dataset: 'compliance_control_metrics',
+      values: ['control_count'],
       title: 'Controls Passing',
       type: 'metric',
       filter: { last_status: 'passed' },
@@ -51,7 +52,8 @@ export const ControlPostureDashboard: Dashboard = {
     },
     {
       id: 'failing_controls',
-      dataset: 'compliance_control_metrics', values: ['control_count'],
+      dataset: 'compliance_control_metrics',
+      values: ['control_count'],
       title: 'Failing or Partial',
       type: 'metric',
       filter: { last_status: { $in: ['failed', 'partial'] } },
@@ -61,7 +63,8 @@ export const ControlPostureDashboard: Dashboard = {
     },
     {
       id: 'expiring_evidence',
-      dataset: 'compliance_evidence_metrics', values: ['evidence_count'],
+      dataset: 'compliance_evidence_metrics',
+      values: ['evidence_count'],
       title: 'Evidence Expiring ≤ 30d',
       type: 'metric',
       filter: {
@@ -74,7 +77,8 @@ export const ControlPostureDashboard: Dashboard = {
     },
     {
       id: 'in_progress_assessments',
-      dataset: 'compliance_assessment_metrics', values: ['assessment_count'],
+      dataset: 'compliance_assessment_metrics',
+      values: ['assessment_count'],
       title: 'Assessments In Progress',
       type: 'metric',
       filter: { status: 'in_progress' },
@@ -84,7 +88,8 @@ export const ControlPostureDashboard: Dashboard = {
     },
     {
       id: 'failing_table',
-      dataset: 'compliance_control_metrics', values: ['control_count'],
+      dataset: 'compliance_control_metrics',
+      values: ['control_count'],
       title: 'Failing Controls (Action Required)',
       type: 'table',
       filter: { last_status: { $in: ['failed', 'partial'] } },
@@ -100,7 +105,8 @@ export const ControlPostureDashboard: Dashboard = {
     },
     {
       id: 'expiring_evidence_table',
-      dataset: 'compliance_evidence_metrics', values: ['evidence_count'],
+      dataset: 'compliance_evidence_metrics',
+      values: ['evidence_count'],
       title: 'Evidence Expiring Soon',
       type: 'table',
       filter: {
@@ -116,7 +122,9 @@ export const ControlPostureDashboard: Dashboard = {
     },
     {
       id: 'assessments_by_month',
-      dataset: 'compliance_assessment_metrics', dimensions: ['assessed_at'], values: ['assessment_count'],
+      dataset: 'compliance_assessment_metrics',
+      dimensions: ['assessed_at'],
+      values: ['assessment_count'],
       title: 'Assessments Completed by Month (last 12 months)',
       type: 'line',
       filter: {

--- a/packages/compliance/src/datasets/compliance_assessment.dataset.ts
+++ b/packages/compliance/src/datasets/compliance_assessment.dataset.ts
@@ -8,9 +8,13 @@ export const ComplianceAssessmentDataset = defineDataset({
   label: 'compliance_assessment metrics',
   object: 'compliance_assessment',
   dimensions: [
-    { name: 'assessed_at', label: 'assessed_at', field: 'assessed_at', type: 'date', dateGranularity: 'month' },
+    {
+      name: 'assessed_at',
+      label: 'assessed_at',
+      field: 'assessed_at',
+      type: 'date',
+      dateGranularity: 'month',
+    },
   ],
-  measures: [
-    { name: 'assessment_count', label: 'assessment_count', aggregate: 'count' },
-  ],
+  measures: [{ name: 'assessment_count', label: 'assessment_count', aggregate: 'count' }],
 });

--- a/packages/compliance/src/datasets/compliance_control.dataset.ts
+++ b/packages/compliance/src/datasets/compliance_control.dataset.ts
@@ -8,7 +8,5 @@ export const ComplianceControlDataset = defineDataset({
   label: 'compliance_control metrics',
   object: 'compliance_control',
   dimensions: [],
-  measures: [
-    { name: 'control_count', label: 'control_count', aggregate: 'count' },
-  ],
+  measures: [{ name: 'control_count', label: 'control_count', aggregate: 'count' }],
 });

--- a/packages/compliance/src/datasets/compliance_evidence.dataset.ts
+++ b/packages/compliance/src/datasets/compliance_evidence.dataset.ts
@@ -8,7 +8,5 @@ export const ComplianceEvidenceDataset = defineDataset({
   label: 'compliance_evidence metrics',
   object: 'compliance_evidence',
   dimensions: [],
-  measures: [
-    { name: 'evidence_count', label: 'evidence_count', aggregate: 'count' },
-  ],
+  measures: [{ name: 'evidence_count', label: 'evidence_count', aggregate: 'count' }],
 });

--- a/packages/content/src/dashboards/editorial_calendar.dashboard.ts
+++ b/packages/content/src/dashboards/editorial_calendar.dashboard.ts
@@ -30,7 +30,8 @@ export const EditorialCalendarDashboard: Dashboard = {
   widgets: [
     {
       id: 'pieces_scheduled',
-      dataset: 'content_piece_metrics', values: ['piece_count'],
+      dataset: 'content_piece_metrics',
+      values: ['piece_count'],
       title: 'Pieces Scheduled (30d)',
       type: 'metric',
       filter: {
@@ -43,7 +44,8 @@ export const EditorialCalendarDashboard: Dashboard = {
     },
     {
       id: 'pieces_in_review',
-      dataset: 'content_piece_metrics', values: ['piece_count'],
+      dataset: 'content_piece_metrics',
+      values: ['piece_count'],
       title: 'Awaiting Approval',
       type: 'metric',
       filter: { status: 'in_review' },
@@ -53,7 +55,8 @@ export const EditorialCalendarDashboard: Dashboard = {
     },
     {
       id: 'pieces_published_30d',
-      dataset: 'content_piece_metrics', values: ['piece_count'],
+      dataset: 'content_piece_metrics',
+      values: ['piece_count'],
       title: 'Published (30d)',
       type: 'metric',
       filter: {
@@ -67,7 +70,8 @@ export const EditorialCalendarDashboard: Dashboard = {
     },
     {
       id: 'pieces_overdue',
-      dataset: 'content_piece_metrics', values: ['piece_count'],
+      dataset: 'content_piece_metrics',
+      values: ['piece_count'],
       title: 'Overdue',
       type: 'metric',
       filter: {
@@ -81,7 +85,8 @@ export const EditorialCalendarDashboard: Dashboard = {
 
     {
       id: 'calendar_main',
-      dataset: 'content_piece_metrics', values: ['piece_count'],
+      dataset: 'content_piece_metrics',
+      values: ['piece_count'],
       title: 'Upcoming Calendar',
       type: 'table',
       filter: {
@@ -97,7 +102,9 @@ export const EditorialCalendarDashboard: Dashboard = {
     },
     {
       id: 'publications_by_channel',
-      dataset: 'content_publication_metrics', dimensions: ['channel'], values: ['publication_count'],
+      dataset: 'content_publication_metrics',
+      dimensions: ['channel'],
+      values: ['publication_count'],
       title: 'Publications by Channel (30d)',
       type: 'pie',
       filter: { published_at: { $gte: '{last_month_start}' } },
@@ -106,7 +113,9 @@ export const EditorialCalendarDashboard: Dashboard = {
     },
     {
       id: 'published_by_month',
-      dataset: 'content_piece_metrics', dimensions: ['published_at'], values: ['piece_count'],
+      dataset: 'content_piece_metrics',
+      dimensions: ['published_at'],
+      values: ['piece_count'],
       title: 'Published Pieces by Month (last 12 months)',
       type: 'line',
       filter: {

--- a/packages/content/src/dashboards/roi_by_channel.dashboard.ts
+++ b/packages/content/src/dashboards/roi_by_channel.dashboard.ts
@@ -32,7 +32,8 @@ export const RoiByChannelDashboard: Dashboard = {
   widgets: [
     {
       id: 'total_views_90d',
-      dataset: 'content_publication_metrics', values: ['sum_total_views'],
+      dataset: 'content_publication_metrics',
+      values: ['sum_total_views'],
       title: 'Views (90d)',
       type: 'metric',
       filter: { published_at: { $gte: '{90_days_ago}' } },
@@ -43,7 +44,8 @@ export const RoiByChannelDashboard: Dashboard = {
     },
     {
       id: 'total_clicks_90d',
-      dataset: 'content_publication_metrics', values: ['sum_total_clicks'],
+      dataset: 'content_publication_metrics',
+      values: ['sum_total_clicks'],
       title: 'Clicks (90d)',
       type: 'metric',
       filter: { published_at: { $gte: '{90_days_ago}' } },
@@ -54,7 +56,8 @@ export const RoiByChannelDashboard: Dashboard = {
     },
     {
       id: 'total_signups_90d',
-      dataset: 'content_publication_metrics', values: ['sum_total_signups'],
+      dataset: 'content_publication_metrics',
+      values: ['sum_total_signups'],
       title: 'Signups (90d)',
       type: 'metric',
       filter: { published_at: { $gte: '{90_days_ago}' } },
@@ -65,7 +68,8 @@ export const RoiByChannelDashboard: Dashboard = {
     },
     {
       id: 'total_revenue_90d',
-      dataset: 'content_publication_metrics', values: ['sum_total_revenue'],
+      dataset: 'content_publication_metrics',
+      values: ['sum_total_revenue'],
       title: 'Attributed Revenue (90d)',
       type: 'metric',
       filter: { published_at: { $gte: '{90_days_ago}' } },
@@ -77,7 +81,9 @@ export const RoiByChannelDashboard: Dashboard = {
 
     {
       id: 'views_by_channel_bar',
-      dataset: 'content_publication_metrics', dimensions: ['channel'], values: ['sum_total_views'],
+      dataset: 'content_publication_metrics',
+      dimensions: ['channel'],
+      values: ['sum_total_views'],
       title: 'Views by Channel (90d)',
       type: 'bar',
       filter: { published_at: { $gte: '{90_days_ago}' } },
@@ -87,7 +93,9 @@ export const RoiByChannelDashboard: Dashboard = {
     },
     {
       id: 'signups_trend',
-      dataset: 'content_metric_metrics', dimensions: ['period_start'], values: ['sum_signups'],
+      dataset: 'content_metric_metrics',
+      dimensions: ['period_start'],
+      values: ['sum_signups'],
       title: 'Signups by Week (90d)',
       type: 'line',
       filter: { period_start: { $gte: '{last_quarter_start}' } },
@@ -104,7 +112,8 @@ export const RoiByChannelDashboard: Dashboard = {
 
     {
       id: 'top_publications',
-      dataset: 'content_publication_metrics', values: ['publication_count'],
+      dataset: 'content_publication_metrics',
+      values: ['publication_count'],
       title: 'Top 10 Publications by Signups',
       type: 'table',
 

--- a/packages/content/src/dashboards/today_workbench.dashboard.ts
+++ b/packages/content/src/dashboards/today_workbench.dashboard.ts
@@ -29,7 +29,8 @@ export const TodayWorkbenchDashboard: Dashboard = {
   widgets: [
     {
       id: 'my_drafts_in_flight',
-      dataset: 'content_piece_metrics', values: ['piece_count'],
+      dataset: 'content_piece_metrics',
+      values: ['piece_count'],
       title: 'My Drafts',
       type: 'metric',
       filter: {
@@ -42,7 +43,8 @@ export const TodayWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'my_pieces_in_review',
-      dataset: 'content_piece_metrics', values: ['piece_count'],
+      dataset: 'content_piece_metrics',
+      values: ['piece_count'],
       title: 'In Review',
       type: 'metric',
       filter: {
@@ -55,7 +57,8 @@ export const TodayWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'scheduled_this_week',
-      dataset: 'content_piece_metrics', values: ['piece_count'],
+      dataset: 'content_piece_metrics',
+      values: ['piece_count'],
       title: 'Scheduled This Week',
       type: 'metric',
       filter: {
@@ -68,7 +71,8 @@ export const TodayWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'published_last_7d',
-      dataset: 'content_piece_metrics', values: ['piece_count'],
+      dataset: 'content_piece_metrics',
+      values: ['piece_count'],
       title: 'Published Last 7d',
       type: 'metric',
       filter: {
@@ -83,7 +87,8 @@ export const TodayWorkbenchDashboard: Dashboard = {
 
     {
       id: 'my_pieces_table',
-      dataset: 'content_piece_metrics', values: ['piece_count'],
+      dataset: 'content_piece_metrics',
+      values: ['piece_count'],
       title: 'Pieces I own (or unassigned), not done',
       type: 'table',
       filter: {
@@ -100,7 +105,8 @@ export const TodayWorkbenchDashboard: Dashboard = {
 
     {
       id: 'signals_to_triage',
-      dataset: 'content_signal_metrics', values: ['signal_count'],
+      dataset: 'content_signal_metrics',
+      values: ['signal_count'],
       title: 'Signals to Triage',
       type: 'table',
       filter: { status: 'captured' },

--- a/packages/content/src/data/index.ts
+++ b/packages/content/src/data/index.ts
@@ -18,7 +18,6 @@ import { Cta } from '../objects/content_cta.object';
 // the array value (correct at runtime) while satisfying the field type.
 const multiRef = (ids: string[]): string => ids as unknown as string;
 
-
 /**
  * Seed data — realistic editorial workload covering the full template
  * surface. Datasets load in dependency order:

--- a/packages/content/src/datasets/content_metric.dataset.ts
+++ b/packages/content/src/datasets/content_metric.dataset.ts
@@ -8,9 +8,13 @@ export const ContentMetricDataset = defineDataset({
   label: 'content_metric metrics',
   object: 'content_metric',
   dimensions: [
-    { name: 'period_start', label: 'period_start', field: 'period_start', type: 'date', dateGranularity: 'week' },
+    {
+      name: 'period_start',
+      label: 'period_start',
+      field: 'period_start',
+      type: 'date',
+      dateGranularity: 'week',
+    },
   ],
-  measures: [
-    { name: 'sum_signups', label: 'sum_signups', aggregate: 'sum', field: 'signups' },
-  ],
+  measures: [{ name: 'sum_signups', label: 'sum_signups', aggregate: 'sum', field: 'signups' }],
 });

--- a/packages/content/src/datasets/content_piece.dataset.ts
+++ b/packages/content/src/datasets/content_piece.dataset.ts
@@ -8,9 +8,13 @@ export const ContentPieceDataset = defineDataset({
   label: 'content_piece metrics',
   object: 'content_piece',
   dimensions: [
-    { name: 'published_at', label: 'published_at', field: 'published_at', type: 'date', dateGranularity: 'month' },
+    {
+      name: 'published_at',
+      label: 'published_at',
+      field: 'published_at',
+      type: 'date',
+      dateGranularity: 'month',
+    },
   ],
-  measures: [
-    { name: 'piece_count', label: 'piece_count', aggregate: 'count' },
-  ],
+  measures: [{ name: 'piece_count', label: 'piece_count', aggregate: 'count' }],
 });

--- a/packages/content/src/datasets/content_publication.dataset.ts
+++ b/packages/content/src/datasets/content_publication.dataset.ts
@@ -7,14 +7,27 @@ export const ContentPublicationDataset = defineDataset({
   name: 'content_publication_metrics',
   label: 'content_publication metrics',
   object: 'content_publication',
-  dimensions: [
-    { name: 'channel', label: 'channel', field: 'channel', type: 'string' },
-  ],
+  dimensions: [{ name: 'channel', label: 'channel', field: 'channel', type: 'string' }],
   measures: [
     { name: 'publication_count', label: 'publication_count', aggregate: 'count' },
     { name: 'sum_total_views', label: 'sum_total_views', aggregate: 'sum', field: 'total_views' },
-    { name: 'sum_total_clicks', label: 'sum_total_clicks', aggregate: 'sum', field: 'total_clicks' },
-    { name: 'sum_total_signups', label: 'sum_total_signups', aggregate: 'sum', field: 'total_signups' },
-    { name: 'sum_total_revenue', label: 'sum_total_revenue', aggregate: 'sum', field: 'total_revenue' },
+    {
+      name: 'sum_total_clicks',
+      label: 'sum_total_clicks',
+      aggregate: 'sum',
+      field: 'total_clicks',
+    },
+    {
+      name: 'sum_total_signups',
+      label: 'sum_total_signups',
+      aggregate: 'sum',
+      field: 'total_signups',
+    },
+    {
+      name: 'sum_total_revenue',
+      label: 'sum_total_revenue',
+      aggregate: 'sum',
+      field: 'total_revenue',
+    },
   ],
 });

--- a/packages/content/src/datasets/content_signal.dataset.ts
+++ b/packages/content/src/datasets/content_signal.dataset.ts
@@ -8,7 +8,5 @@ export const ContentSignalDataset = defineDataset({
   label: 'content_signal metrics',
   object: 'content_signal',
   dimensions: [],
-  measures: [
-    { name: 'signal_count', label: 'signal_count', aggregate: 'count' },
-  ],
+  measures: [{ name: 'signal_count', label: 'signal_count', aggregate: 'count' }],
 });

--- a/packages/contracts/src/dashboards/renewals_at_risk.dashboard.ts
+++ b/packages/contracts/src/dashboards/renewals_at_risk.dashboard.ts
@@ -33,7 +33,8 @@ export const RenewalsAtRiskDashboard: Dashboard = {
   widgets: [
     {
       id: 'expiring_60',
-      dataset: 'contracts_contract_metrics', values: ['contract_count'],
+      dataset: 'contracts_contract_metrics',
+      values: ['contract_count'],
       title: 'Expiring ≤ 60 days',
       type: 'metric',
       // NOTE: filter on base fields only — formula fields (`is_expiring_soon`,
@@ -49,7 +50,8 @@ export const RenewalsAtRiskDashboard: Dashboard = {
     },
     {
       id: 'auto_renewing_30',
-      dataset: 'contracts_contract_metrics', values: ['contract_count'],
+      dataset: 'contracts_contract_metrics',
+      values: ['contract_count'],
       title: 'Auto-Renewing ≤ 30d',
       type: 'metric',
       filter: {
@@ -63,7 +65,8 @@ export const RenewalsAtRiskDashboard: Dashboard = {
     },
     {
       id: 'pending_approval',
-      dataset: 'contracts_contract_metrics', values: ['contract_count'],
+      dataset: 'contracts_contract_metrics',
+      values: ['contract_count'],
       title: 'Pending Approval',
       type: 'metric',
       filter: {
@@ -76,7 +79,8 @@ export const RenewalsAtRiskDashboard: Dashboard = {
     },
     {
       id: 'active_total_value',
-      dataset: 'contracts_contract_metrics', values: ['sum_total_value'],
+      dataset: 'contracts_contract_metrics',
+      values: ['sum_total_value'],
       title: 'Active Portfolio Value',
       type: 'metric',
       filter: { status: 'active' },
@@ -86,7 +90,8 @@ export const RenewalsAtRiskDashboard: Dashboard = {
     },
     {
       id: 'expiring_table',
-      dataset: 'contracts_contract_metrics', values: ['contract_count'],
+      dataset: 'contracts_contract_metrics',
+      values: ['contract_count'],
       title: 'Expiring Contracts (Next 60d)',
       type: 'table',
       // Only `{today}` is resolved client-side by the data endpoint; tokens
@@ -106,7 +111,8 @@ export const RenewalsAtRiskDashboard: Dashboard = {
     },
     {
       id: 'pending_obligations',
-      dataset: 'contracts_obligation_metrics', values: ['obligation_count'],
+      dataset: 'contracts_obligation_metrics',
+      values: ['obligation_count'],
       title: 'Open Obligations',
       type: 'table',
       filter: { status: 'open' },
@@ -119,7 +125,9 @@ export const RenewalsAtRiskDashboard: Dashboard = {
     },
     {
       id: 'signed_by_month',
-      dataset: 'contracts_contract_metrics', dimensions: ['signed_date'], values: ['contract_count'],
+      dataset: 'contracts_contract_metrics',
+      dimensions: ['signed_date'],
+      values: ['contract_count'],
       title: 'Contracts Signed by Month (last 12 months)',
       type: 'line',
       filter: { signed_date: { $gte: '{12_months_ago}' } },

--- a/packages/contracts/src/datasets/contracts_contract.dataset.ts
+++ b/packages/contracts/src/datasets/contracts_contract.dataset.ts
@@ -8,7 +8,13 @@ export const ContractsContractDataset = defineDataset({
   label: 'contracts_contract metrics',
   object: 'contracts_contract',
   dimensions: [
-    { name: 'signed_date', label: 'signed_date', field: 'signed_date', type: 'date', dateGranularity: 'month' },
+    {
+      name: 'signed_date',
+      label: 'signed_date',
+      field: 'signed_date',
+      type: 'date',
+      dateGranularity: 'month',
+    },
   ],
   measures: [
     { name: 'contract_count', label: 'contract_count', aggregate: 'count' },

--- a/packages/contracts/src/datasets/contracts_obligation.dataset.ts
+++ b/packages/contracts/src/datasets/contracts_obligation.dataset.ts
@@ -8,7 +8,5 @@ export const ContractsObligationDataset = defineDataset({
   label: 'contracts_obligation metrics',
   object: 'contracts_obligation',
   dimensions: [],
-  measures: [
-    { name: 'obligation_count', label: 'obligation_count', aggregate: 'count' },
-  ],
+  measures: [{ name: 'obligation_count', label: 'obligation_count', aggregate: 'count' }],
 });

--- a/packages/expense/src/dashboards/expenses_overview.dashboard.ts
+++ b/packages/expense/src/dashboards/expenses_overview.dashboard.ts
@@ -31,7 +31,8 @@ export const ExpensesOverviewDashboard: Dashboard = {
   widgets: [
     {
       id: 'awaiting_approval',
-      dataset: 'expense_report_metrics', values: ['report_count'],
+      dataset: 'expense_report_metrics',
+      values: ['report_count'],
       title: 'Awaiting Approval',
       type: 'metric',
       filter: { status: 'submitted' },
@@ -41,7 +42,8 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'awaiting_reimbursement',
-      dataset: 'expense_report_metrics', values: ['report_count'],
+      dataset: 'expense_report_metrics',
+      values: ['report_count'],
       title: 'To Reimburse',
       type: 'metric',
       filter: { status: 'approved' },
@@ -51,7 +53,8 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'owed_amount',
-      dataset: 'expense_report_metrics', values: ['sum_total_amount'],
+      dataset: 'expense_report_metrics',
+      values: ['sum_total_amount'],
       title: 'Owed to Employees ($)',
       type: 'metric',
       filter: { status: 'approved' },
@@ -61,7 +64,8 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'reimbursed_total',
-      dataset: 'expense_report_metrics', values: ['sum_total_amount'],
+      dataset: 'expense_report_metrics',
+      values: ['sum_total_amount'],
       title: 'Reimbursed ($)',
       type: 'metric',
       filter: { status: 'reimbursed' },
@@ -71,7 +75,8 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'pending_reports_table',
-      dataset: 'expense_report_metrics', values: ['report_count'],
+      dataset: 'expense_report_metrics',
+      values: ['report_count'],
       title: 'Reports Awaiting Approval',
       type: 'table',
       filter: { status: 'submitted' },
@@ -84,7 +89,8 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'to_reimburse_table',
-      dataset: 'expense_report_metrics', values: ['report_count'],
+      dataset: 'expense_report_metrics',
+      values: ['report_count'],
       title: 'Approved — To Reimburse',
       type: 'table',
       filter: { status: 'approved' },
@@ -97,7 +103,9 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'spend_by_category',
-      dataset: 'expense_line_metrics', dimensions: ['category'], values: ['sum_amount'],
+      dataset: 'expense_line_metrics',
+      dimensions: ['category'],
+      values: ['sum_amount'],
       title: 'Spend by Category',
       type: 'bar',
       layout: { x: 0, y: 7, w: 5, h: 5 },
@@ -111,7 +119,9 @@ export const ExpensesOverviewDashboard: Dashboard = {
     },
     {
       id: 'spend_by_month',
-      dataset: 'expense_report_metrics', dimensions: ['reimbursed_at'], values: ['sum_total_amount'],
+      dataset: 'expense_report_metrics',
+      dimensions: ['reimbursed_at'],
+      values: ['sum_total_amount'],
       title: 'Reimbursed by Month (last 12 months)',
       type: 'line',
       filter: { reimbursed_at: { $gte: '{12_months_ago}' } },

--- a/packages/expense/src/datasets/expense_line.dataset.ts
+++ b/packages/expense/src/datasets/expense_line.dataset.ts
@@ -7,10 +7,6 @@ export const ExpenseLineDataset = defineDataset({
   name: 'expense_line_metrics',
   label: 'expense_line metrics',
   object: 'expense_line',
-  dimensions: [
-    { name: 'category', label: 'category', field: 'category', type: 'string' },
-  ],
-  measures: [
-    { name: 'sum_amount', label: 'sum_amount', aggregate: 'sum', field: 'amount' },
-  ],
+  dimensions: [{ name: 'category', label: 'category', field: 'category', type: 'string' }],
+  measures: [{ name: 'sum_amount', label: 'sum_amount', aggregate: 'sum', field: 'amount' }],
 });

--- a/packages/expense/src/datasets/expense_report.dataset.ts
+++ b/packages/expense/src/datasets/expense_report.dataset.ts
@@ -8,10 +8,21 @@ export const ExpenseReportDataset = defineDataset({
   label: 'expense_report metrics',
   object: 'expense_report',
   dimensions: [
-    { name: 'reimbursed_at', label: 'reimbursed_at', field: 'reimbursed_at', type: 'date', dateGranularity: 'month' },
+    {
+      name: 'reimbursed_at',
+      label: 'reimbursed_at',
+      field: 'reimbursed_at',
+      type: 'date',
+      dateGranularity: 'month',
+    },
   ],
   measures: [
     { name: 'report_count', label: 'report_count', aggregate: 'count' },
-    { name: 'sum_total_amount', label: 'sum_total_amount', aggregate: 'sum', field: 'total_amount' },
+    {
+      name: 'sum_total_amount',
+      label: 'sum_total_amount',
+      aggregate: 'sum',
+      field: 'total_amount',
+    },
   ],
 });

--- a/packages/helpdesk/src/dashboards/agent_workbench.dashboard.ts
+++ b/packages/helpdesk/src/dashboards/agent_workbench.dashboard.ts
@@ -30,7 +30,8 @@ export const AgentWorkbenchDashboard: Dashboard = {
   widgets: [
     {
       id: 'my_open',
-      dataset: 'ticket_metrics', values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      values: ['ticket_count'],
       title: 'My Open Tickets',
       type: 'metric',
       filter: {
@@ -43,7 +44,8 @@ export const AgentWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'breaching_resolution',
-      dataset: 'ticket_metrics', values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      values: ['ticket_count'],
       title: 'SLA Breaching',
       type: 'metric',
       filter: {
@@ -56,7 +58,8 @@ export const AgentWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'angry',
-      dataset: 'ticket_metrics', values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      values: ['ticket_count'],
       title: 'Angry Customers',
       type: 'metric',
       filter: {
@@ -69,7 +72,8 @@ export const AgentWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'awaiting_triage',
-      dataset: 'ticket_metrics', values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      values: ['ticket_count'],
       title: 'Awaiting Triage',
       type: 'metric',
       filter: { status: 'new' },
@@ -80,7 +84,8 @@ export const AgentWorkbenchDashboard: Dashboard = {
 
     {
       id: 'my_queue_table',
-      dataset: 'ticket_metrics', values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      values: ['ticket_count'],
       title: 'My Queue (Priority Sorted)',
       type: 'table',
       filter: {
@@ -96,7 +101,8 @@ export const AgentWorkbenchDashboard: Dashboard = {
     },
     {
       id: 'breaching_table',
-      dataset: 'ticket_metrics', values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      values: ['ticket_count'],
       title: 'SLA Breaches',
       type: 'table',
       filter: {

--- a/packages/helpdesk/src/dashboards/manager_overview.dashboard.ts
+++ b/packages/helpdesk/src/dashboards/manager_overview.dashboard.ts
@@ -26,7 +26,8 @@ export const ManagerOverviewDashboard: Dashboard = {
   widgets: [
     {
       id: 'total_open',
-      dataset: 'ticket_metrics', values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      values: ['ticket_count'],
       title: 'Open Tickets',
       type: 'metric',
       filter: { status: { $nin: ['closed', 'resolved'] } },
@@ -36,7 +37,8 @@ export const ManagerOverviewDashboard: Dashboard = {
     },
     {
       id: 'breaching_overview',
-      dataset: 'ticket_metrics', values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      values: ['ticket_count'],
       title: 'SLA Breaching',
       type: 'metric',
       filter: {
@@ -49,7 +51,8 @@ export const ManagerOverviewDashboard: Dashboard = {
     },
     {
       id: 'escalated',
-      dataset: 'ticket_metrics', values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      values: ['ticket_count'],
       title: 'Escalated',
       type: 'metric',
       filter: { status: 'escalated' },
@@ -59,7 +62,8 @@ export const ManagerOverviewDashboard: Dashboard = {
     },
     {
       id: 'avg_csat',
-      dataset: 'ticket_metrics', values: ['avg_csat'],
+      dataset: 'ticket_metrics',
+      values: ['avg_csat'],
       title: 'Avg CSAT',
       type: 'metric',
       filter: {
@@ -74,14 +78,18 @@ export const ManagerOverviewDashboard: Dashboard = {
 
     {
       id: 'tickets_by_status',
-      dataset: 'ticket_metrics', dimensions: ['status'], values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      dimensions: ['status'],
+      values: ['ticket_count'],
       title: 'Tickets by Status',
       type: 'bar',
       layout: { x: 0, y: 2, w: 6, h: 4 },
     },
     {
       id: 'tickets_by_sentiment',
-      dataset: 'ticket_metrics', dimensions: ['ai_sentiment'], values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      dimensions: ['ai_sentiment'],
+      values: ['ticket_count'],
       title: 'Sentiment Distribution',
       type: 'pie',
       filter: { status: { $nin: ['closed'] } },
@@ -90,14 +98,18 @@ export const ManagerOverviewDashboard: Dashboard = {
 
     {
       id: 'tickets_by_category',
-      dataset: 'ticket_metrics', dimensions: ['ai_category'], values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      dimensions: ['ai_category'],
+      values: ['ticket_count'],
       title: 'AI Category Mix',
       type: 'bar',
       layout: { x: 0, y: 6, w: 6, h: 4 },
     },
     {
       id: 'tickets_by_channel',
-      dataset: 'ticket_metrics', dimensions: ['channel'], values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      dimensions: ['channel'],
+      values: ['ticket_count'],
       title: 'Volume by Channel',
       type: 'bar',
       layout: { x: 6, y: 6, w: 6, h: 4 },
@@ -105,7 +117,8 @@ export const ManagerOverviewDashboard: Dashboard = {
 
     {
       id: 'recent_escalated',
-      dataset: 'ticket_metrics', values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      values: ['ticket_count'],
       title: 'Recently Escalated',
       type: 'table',
       filter: { status: 'escalated' },
@@ -126,7 +139,9 @@ export const ManagerOverviewDashboard: Dashboard = {
     },
     {
       id: 'resolutions_by_day',
-      dataset: 'ticket_metrics', dimensions: ['resolved_at'], values: ['ticket_count'],
+      dataset: 'ticket_metrics',
+      dimensions: ['resolved_at'],
+      values: ['ticket_count'],
       title: 'Resolutions by Day (last 30 days)',
       type: 'line',
       filter: {

--- a/packages/helpdesk/src/datasets/ticket.dataset.ts
+++ b/packages/helpdesk/src/datasets/ticket.dataset.ts
@@ -18,7 +18,13 @@ export const TicketDataset = defineDataset({
     { name: 'ai_category', label: 'AI Category', field: 'ai_category', type: 'string' },
     { name: 'ai_sentiment', label: 'AI Sentiment', field: 'ai_sentiment', type: 'string' },
     { name: 'priority', label: 'Priority', field: 'priority', type: 'string' },
-    { name: 'resolved_at', label: 'Resolved At', field: 'resolved_at', type: 'date', dateGranularity: 'day' },
+    {
+      name: 'resolved_at',
+      label: 'Resolved At',
+      field: 'resolved_at',
+      type: 'date',
+      dateGranularity: 'day',
+    },
   ],
   measures: [
     { name: 'ticket_count', label: 'Tickets', aggregate: 'count' },

--- a/packages/hr/src/dashboards/hr_admin.dashboard.ts
+++ b/packages/hr/src/dashboards/hr_admin.dashboard.ts
@@ -32,7 +32,8 @@ export const HrAdminDashboard: Dashboard = {
   widgets: [
     {
       id: 'headcount',
-      dataset: 'hr_employee_metrics', values: ['employee_count'],
+      dataset: 'hr_employee_metrics',
+      values: ['employee_count'],
       title: 'Active Headcount',
       type: 'metric',
       filter: { status: 'active' },
@@ -42,7 +43,8 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'on_leave',
-      dataset: 'hr_employee_metrics', values: ['employee_count'],
+      dataset: 'hr_employee_metrics',
+      values: ['employee_count'],
       title: 'On Leave',
       type: 'metric',
       filter: { status: 'on_leave' },
@@ -52,7 +54,8 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'new_hires_30d',
-      dataset: 'hr_employee_metrics', values: ['employee_count'],
+      dataset: 'hr_employee_metrics',
+      values: ['employee_count'],
       title: 'New Hires (30d)',
       type: 'metric',
       filter: { hire_date: { $gte: '{30_days_ago}' }, status: { $ne: 'terminated' } },
@@ -63,7 +66,8 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'pending_time_off',
-      dataset: 'hr_time_off_request_metrics', values: ['request_count'],
+      dataset: 'hr_time_off_request_metrics',
+      values: ['request_count'],
       title: 'My Pending Approvals',
       type: 'metric',
       filter: { status: 'submitted', approver: '{current_user_id}' },
@@ -73,7 +77,8 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'expiring_docs',
-      dataset: 'hr_document_metrics', values: ['document_count'],
+      dataset: 'hr_document_metrics',
+      values: ['document_count'],
       title: 'Documents Expiring (30d)',
       type: 'metric',
       filter: {
@@ -85,7 +90,8 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'expired_docs',
-      dataset: 'hr_document_metrics', values: ['document_count'],
+      dataset: 'hr_document_metrics',
+      values: ['document_count'],
       title: 'Already Expired',
       type: 'metric',
       filter: { expires_at: { $lt: '{today}' } },
@@ -95,7 +101,9 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'headcount_by_dept',
-      dataset: 'hr_employee_metrics', dimensions: ['department'], values: ['employee_count'],
+      dataset: 'hr_employee_metrics',
+      dimensions: ['department'],
+      values: ['employee_count'],
       title: 'Headcount by Department',
       type: 'bar',
       filter: { status: { $ne: 'terminated' } },
@@ -103,7 +111,8 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'ooo_today',
-      dataset: 'hr_time_off_request_metrics', values: ['request_count'],
+      dataset: 'hr_time_off_request_metrics',
+      values: ['request_count'],
       title: 'Out of Office Today',
       type: 'table',
       filter: {
@@ -120,7 +129,8 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'pending_time_off_table',
-      dataset: 'hr_time_off_request_metrics', values: ['request_count'],
+      dataset: 'hr_time_off_request_metrics',
+      values: ['request_count'],
       title: 'My Pending Time-Off Requests',
       type: 'table',
       filter: { status: 'submitted', approver: '{current_user_id}' },
@@ -133,7 +143,8 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'expiring_docs_table',
-      dataset: 'hr_document_metrics', values: ['document_count'],
+      dataset: 'hr_document_metrics',
+      values: ['document_count'],
       title: 'Documents Expiring Soon',
       type: 'table',
       filter: { expires_at: { $gte: '{today}', $lte: '{today+30}' } },
@@ -146,7 +157,9 @@ export const HrAdminDashboard: Dashboard = {
     },
     {
       id: 'hires_by_month',
-      dataset: 'hr_employee_metrics', dimensions: ['hire_date'], values: ['employee_count'],
+      dataset: 'hr_employee_metrics',
+      dimensions: ['hire_date'],
+      values: ['employee_count'],
       title: 'Hires by Month (last 12 months)',
       type: 'line',
       filter: { hire_date: { $gte: '{12_months_ago}' } },

--- a/packages/hr/src/datasets/hr_document.dataset.ts
+++ b/packages/hr/src/datasets/hr_document.dataset.ts
@@ -8,7 +8,5 @@ export const HrDocumentDataset = defineDataset({
   label: 'hr_document metrics',
   object: 'hr_document',
   dimensions: [],
-  measures: [
-    { name: 'document_count', label: 'document_count', aggregate: 'count' },
-  ],
+  measures: [{ name: 'document_count', label: 'document_count', aggregate: 'count' }],
 });

--- a/packages/hr/src/datasets/hr_employee.dataset.ts
+++ b/packages/hr/src/datasets/hr_employee.dataset.ts
@@ -9,9 +9,13 @@ export const HrEmployeeDataset = defineDataset({
   object: 'hr_employee',
   dimensions: [
     { name: 'department', label: 'department', field: 'department', type: 'string' },
-    { name: 'hire_date', label: 'hire_date', field: 'hire_date', type: 'date', dateGranularity: 'month' },
+    {
+      name: 'hire_date',
+      label: 'hire_date',
+      field: 'hire_date',
+      type: 'date',
+      dateGranularity: 'month',
+    },
   ],
-  measures: [
-    { name: 'employee_count', label: 'employee_count', aggregate: 'count' },
-  ],
+  measures: [{ name: 'employee_count', label: 'employee_count', aggregate: 'count' }],
 });

--- a/packages/hr/src/datasets/hr_time_off_request.dataset.ts
+++ b/packages/hr/src/datasets/hr_time_off_request.dataset.ts
@@ -8,7 +8,5 @@ export const HrTimeOffRequestDataset = defineDataset({
   label: 'hr_time_off_request metrics',
   object: 'hr_time_off_request',
   dimensions: [],
-  measures: [
-    { name: 'request_count', label: 'request_count', aggregate: 'count' },
-  ],
+  measures: [{ name: 'request_count', label: 'request_count', aggregate: 'count' }],
 });

--- a/packages/procurement/src/dashboards/spend_at_a_glance.dashboard.ts
+++ b/packages/procurement/src/dashboards/spend_at_a_glance.dashboard.ts
@@ -35,7 +35,8 @@ export const SpendAtAGlanceDashboard: Dashboard = {
   widgets: [
     {
       id: 'awaiting_approval',
-      dataset: 'procurement_request_metrics', values: ['request_count'],
+      dataset: 'procurement_request_metrics',
+      values: ['request_count'],
       title: 'PRs Awaiting Approval',
       type: 'metric',
       filter: { status: 'submitted', estimated_amount: { $gte: 5000 } },
@@ -45,7 +46,8 @@ export const SpendAtAGlanceDashboard: Dashboard = {
     },
     {
       id: 'open_pos',
-      dataset: 'procurement_order_metrics', values: ['order_count'],
+      dataset: 'procurement_order_metrics',
+      values: ['order_count'],
       title: 'Open Purchase Orders',
       type: 'metric',
       filter: { status: { $in: ['sent', 'partial'] } },
@@ -55,7 +57,8 @@ export const SpendAtAGlanceDashboard: Dashboard = {
     },
     {
       id: 'overdue_pos',
-      dataset: 'procurement_order_metrics', values: ['order_count'],
+      dataset: 'procurement_order_metrics',
+      values: ['order_count'],
       title: 'Overdue Deliveries',
       type: 'metric',
       filter: {
@@ -68,7 +71,8 @@ export const SpendAtAGlanceDashboard: Dashboard = {
     },
     {
       id: 'open_commitment',
-      dataset: 'procurement_order_metrics', values: ['sum_total_amount'],
+      dataset: 'procurement_order_metrics',
+      values: ['sum_total_amount'],
       title: 'Open Commitment ($)',
       type: 'metric',
       filter: { status: { $in: ['sent', 'partial'] } },
@@ -78,7 +82,8 @@ export const SpendAtAGlanceDashboard: Dashboard = {
     },
     {
       id: 'pending_requests_table',
-      dataset: 'procurement_request_metrics', values: ['request_count'],
+      dataset: 'procurement_request_metrics',
+      values: ['request_count'],
       title: 'Requests Awaiting Approval',
       type: 'table',
       filter: { status: 'submitted' },
@@ -91,7 +96,8 @@ export const SpendAtAGlanceDashboard: Dashboard = {
     },
     {
       id: 'open_pos_table',
-      dataset: 'procurement_order_metrics', values: ['order_count'],
+      dataset: 'procurement_order_metrics',
+      values: ['order_count'],
       title: 'Open Purchase Orders',
       type: 'table',
       filter: { status: { $in: ['sent', 'partial'] } },
@@ -104,7 +110,9 @@ export const SpendAtAGlanceDashboard: Dashboard = {
     },
     {
       id: 'po_value_by_month',
-      dataset: 'procurement_order_metrics', dimensions: ['order_date'], values: ['sum_total_amount'],
+      dataset: 'procurement_order_metrics',
+      dimensions: ['order_date'],
+      values: ['sum_total_amount'],
       title: 'PO Value by Month (last 12 months)',
       type: 'line',
       filter: { order_date: { $gte: '{12_months_ago}' } },

--- a/packages/procurement/src/datasets/procurement_order.dataset.ts
+++ b/packages/procurement/src/datasets/procurement_order.dataset.ts
@@ -8,10 +8,21 @@ export const ProcurementOrderDataset = defineDataset({
   label: 'procurement_order metrics',
   object: 'procurement_order',
   dimensions: [
-    { name: 'order_date', label: 'order_date', field: 'order_date', type: 'date', dateGranularity: 'month' },
+    {
+      name: 'order_date',
+      label: 'order_date',
+      field: 'order_date',
+      type: 'date',
+      dateGranularity: 'month',
+    },
   ],
   measures: [
     { name: 'order_count', label: 'order_count', aggregate: 'count' },
-    { name: 'sum_total_amount', label: 'sum_total_amount', aggregate: 'sum', field: 'total_amount' },
+    {
+      name: 'sum_total_amount',
+      label: 'sum_total_amount',
+      aggregate: 'sum',
+      field: 'total_amount',
+    },
   ],
 });

--- a/packages/procurement/src/datasets/procurement_request.dataset.ts
+++ b/packages/procurement/src/datasets/procurement_request.dataset.ts
@@ -8,7 +8,5 @@ export const ProcurementRequestDataset = defineDataset({
   label: 'procurement_request metrics',
   object: 'procurement_request',
   dimensions: [],
-  measures: [
-    { name: 'request_count', label: 'request_count', aggregate: 'count' },
-  ],
+  measures: [{ name: 'request_count', label: 'request_count', aggregate: 'count' }],
 });

--- a/packages/todo/src/dashboards/my_work.dashboard.ts
+++ b/packages/todo/src/dashboards/my_work.dashboard.ts
@@ -29,7 +29,8 @@ export const MyWorkDashboard: Dashboard = {
   widgets: [
     {
       id: 'my_open_tasks',
-      dataset: 'todo_task_metrics', values: ['task_count'],
+      dataset: 'todo_task_metrics',
+      values: ['task_count'],
       title: 'My Open Tasks',
       type: 'metric',
       filter: { assignee: '{current_user_id}', status: { $in: ['todo', 'doing'] } },
@@ -39,7 +40,8 @@ export const MyWorkDashboard: Dashboard = {
     },
     {
       id: 'my_overdue',
-      dataset: 'todo_task_metrics', values: ['task_count'],
+      dataset: 'todo_task_metrics',
+      values: ['task_count'],
       title: 'Overdue',
       type: 'metric',
       filter: {
@@ -53,7 +55,8 @@ export const MyWorkDashboard: Dashboard = {
     },
     {
       id: 'done_this_week',
-      dataset: 'todo_task_metrics', values: ['task_count'],
+      dataset: 'todo_task_metrics',
+      values: ['task_count'],
       title: 'Done This Week',
       type: 'metric',
       filter: {
@@ -68,7 +71,8 @@ export const MyWorkDashboard: Dashboard = {
     },
     {
       id: 'recent_overdue_list',
-      dataset: 'todo_task_metrics', values: ['task_count'],
+      dataset: 'todo_task_metrics',
+      values: ['task_count'],
       title: 'Overdue Tasks',
       type: 'table',
       filter: {
@@ -84,7 +88,9 @@ export const MyWorkDashboard: Dashboard = {
     },
     {
       id: 'throughput_by_week',
-      dataset: 'todo_task_metrics', dimensions: ['completed_at'], values: ['task_count'],
+      dataset: 'todo_task_metrics',
+      dimensions: ['completed_at'],
+      values: ['task_count'],
       title: 'My Throughput by Week (last 12 weeks)',
       type: 'line',
       filter: {

--- a/packages/todo/src/data/index.ts
+++ b/packages/todo/src/data/index.ts
@@ -11,7 +11,6 @@ import { Label } from '../objects/todo_label.object';
 // the array value (correct at runtime) while satisfying the field type.
 const multiRef = (ids: string[]): string => ids as unknown as string;
 
-
 /**
  * Seed data — realistic, business-like task content covering the full
  * surface of the template:

--- a/packages/todo/src/datasets/todo_task.dataset.ts
+++ b/packages/todo/src/datasets/todo_task.dataset.ts
@@ -8,9 +8,13 @@ export const TodoTaskDataset = defineDataset({
   label: 'todo_task metrics',
   object: 'todo_task',
   dimensions: [
-    { name: 'completed_at', label: 'completed_at', field: 'completed_at', type: 'date', dateGranularity: 'week' },
+    {
+      name: 'completed_at',
+      label: 'completed_at',
+      field: 'completed_at',
+      type: 'date',
+      dateGranularity: 'week',
+    },
   ],
-  measures: [
-    { name: 'task_count', label: 'task_count', aggregate: 'count' },
-  ],
+  measures: [{ name: 'task_count', label: 'task_count', aggregate: 'count' }],
 });


### PR DESCRIPTION
Follow-up to #25.

The CI `format:check` step was **already failing on main** before the v9 upgrade (commit `8cd5918` push run = failure) — pre-existing prettier debt across ~20 dataset/dashboard files. The v9 upgrade (#25) touched a few of those files, so CI stayed red.

This runs the repo's canonical `pnpm format` (`prettier --write .`) to normalize all matched files.

- ✅ `pnpm format:check` — "All matched files use Prettier code style!"
- ✅ `pnpm -r typecheck`, `pnpm -r build` — pass
- No semantic changes: dataset `dateGranularity` and all v9 dataset bindings preserved (verified 9/9 datasets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)