### PR TITLE
fix(ui): faithfully complete two approximated ListView filters (ADR-0017)

### DIFF
--- a/docs/platform-issue-table-widget-warning.md
+++ b/docs/platform-issue-table-widget-warning.md
@@ -1,0 +1,92 @@
+# Build-time warning: `table`/`pivot` dashboard widget bound to a count-only dataset binding (likely a record list that should be a ListView)
+
+> Upstream target: **`objectstack-ai/framework`** (the `@objectstack/*` platform packages — `@objectstack/spec`, `@objectstack/cli`, `@objectstack/core` all resolve to `git+https://github.com/objectstack-ai/framework.git`).
+> Suggested labels: `enhancement`, `analytics`
+> Downstream context / manual fix: [objectstack-ai/templates#27](https://github.com/objectstack-ai/templates/pull/27)
+
+## Problem
+
+After the v9 single-form cutover (ADR-0021), a `DashboardWidget` is analytics-only: it binds to a `dataset` and selects `values` (measures) + optional `dimensions`. A widget whose binding resolves to **only `count` measures with no `dimensions`** asks the analytics service for a single grouped row — one number.
+
+That is exactly the right shape for a `type:'metric'` widget. It is the **wrong** shape for a `type:'table'` (or `type:'pivot'`) widget, which the author almost always intends as a **flat list of individual records**. The table renders, but it collapses to a single summary row containing the count — the per-record detail the author wanted is silently gone.
+
+Per the v9 release notes: *"a flat record listing is not an analytics dataset — model it as an object-bound ListView (ADR-0017)."* But `objectstack build` emits **no error and no warning** for this configuration, so the mistake is invisible until the page renders in a browser.
+
+## Impact
+
+- In one downstream template repo this bit **19 `type:'table'` widgets across 11 dashboards** — every one a record listing that silently collapsed to a single count after the ADR-0021 cutover. See [objectstack-ai/templates#27](https://github.com/objectstack-ai/templates/pull/27), which removed them and rebuilt the listings as ADR-0017 object ListViews by hand.
+- The build was **green the entire time** — `zod` schema validation, `tsc`, and marketplace compose all passed. Nothing flagged it. The regression only surfaced through manual page inspection.
+- This is a predictable migration trap, not a one-off authoring slip: any pre-v9 dashboard that used a `table` widget as a record list converts into exactly this broken shape during the single-form cutover. Every team migrating to v9 is exposed to it.
+
+## Minimal reproduction
+
+A `table` widget bound to a binding that selects only the `count` measure and groups by no dimension:
+
+```ts
+// dataset — has a count measure (the only one this widget selects)
+export const ExpenseReportDataset = defineDataset({
+  name: 'expense_report_metrics',
+  object: 'expense_report',
+  measures: [
+    { name: 'report_count', label: 'report_count', aggregate: 'count' },
+    // (a sum measure also exists, but the widget below does not select it)
+  ],
+  dimensions: [/* ... */],
+});
+
+// widget — INTENDS a per-record list, but binds count-only with no dimensions
+{
+  id: 'pending_reports_table',
+  type: 'table',
+  dataset: 'expense_report_metrics',
+  values: ['report_count'],          // ← resolves to a single count measure
+  // (no `dimensions`)                // ← no grouping → one row
+  filter: { status: 'submitted' },
+  options: {
+    columns: ['title', 'requester', 'total_amount', 'cost_center', 'submitted_at'],
+    pageSize: 10,
+    sort: [{ field: 'total_amount', order: 'desc' }],
+  },
+}
+```
+
+**Observed:** `objectstack build` succeeds with no diagnostic. At runtime the table shows **one row** holding the count value — not the list of submitted reports.
+
+**Note on the heuristic:** the signal lives on the **widget's binding**, not the dataset alone. Here the dataset *does* have a `sum` measure and a dimension, yet the widget is still broken because *it* selects only `report_count` and declares no `dimensions`. A rule keyed purely on "the dataset's measures are all count" would miss this case. Key the check on what the widget actually requests.
+
+## Expected behavior
+
+`objectstack build` should emit a **warning** (non-fatal — does not break existing builds) when, for a single `DashboardWidget`:
+
+1. `type` is `'table'` or `'pivot'`, **and**
+2. the `values` it selects resolve to measures that are **all `aggregate: 'count'`**, **and**
+3. the widget declares **no `dimensions`** (no grouping).
+
+Suggested message:
+
+```
+warning  dashboard "expenses_overview_dashboard" › widget "pending_reports_table":
+         a 'table' widget bound to dataset "expense_report_metrics" selects only
+         count measure(s) (report_count) and no dimensions, so it renders a single
+         summary row — not a per-record list.
+
+         A flat record listing is not an analytics dataset. Model it as an
+         object-bound ListView (ADR-0017) surfaced through app navigation, and use
+         a 'metric' widget here if you only need the count.
+
+         If a single-row table is intentional, add an explicit dimension or
+         suppress with: // objectstack-disable-next-line table-count-only
+```
+
+Emitting it as a **warning** (not an error) keeps it non-breaking and lets teams suppress intentional cases, while making the trap visible in CI logs and local builds. Teams that want it to be fatal can promote it to an error via lint config.
+
+## Implementation notes
+
+- Place the check in the **build/validation pipeline**, in the pass that runs *after* dataset references are resolved — i.e. once each widget's `dataset` name is linked to its `defineDataset` and each entry in `values` is resolved to a concrete measure with a known `aggregate`. The check needs the resolved measure `aggregate` types, so it cannot run on the raw widget literal during pure `zod` schema validation; it belongs in the semantic/cross-reference validation stage (alongside the existing "widget requires `dataset` + `values`" analytics-only check), not in schema parsing.
+- This is a pure static analysis over already-loaded metadata — no runtime query needed. Per widget: resolve `values` → measures, check `every(m => m.aggregate === 'count')`, and check `!widget.dimensions?.length`. Gate on `type ∈ {'table','pivot'}`.
+- Consider a registry entry (e.g. rule id `table-count-only`) so it can be configured/suppressed consistently with other build diagnostics, and so the suppression comment in the message is real.
+- A coarser dataset-level variant ("dataset has only count measures and no usable dimensions, yet a table widget binds it") is easier to compute but less precise — it both misses widgets like the repro above (dataset has other measures) and risks false positives. Prefer the widget-binding-level rule.
+
+## Downstream reference
+
+[objectstack-ai/templates#27](https://github.com/objectstack-ai/templates/pull/27) — *"fix(ui): migrate dashboard record-listing tables to ListViews (ADR-0017)"* — is the manual downstream remediation: it removed all 19 collapsed table widgets and rebuilt the genuine record listings as object-bound ListViews. A build-time warning like the one proposed here would have caught all 19 at migration time instead of at render time.

--- a/packages/content/src/views/content_piece.view.ts
+++ b/packages/content/src/views/content_piece.view.ts
@@ -7,6 +7,7 @@ import { defineView } from '@objectstack/spec/ui';
  *
  *   • all_pieces            — default grid, grouped by status
  *   • piece_board           — kanban auto-derived from status select
+ *   • my_pieces             — assignee = me AND status in active pipeline (see note)
  *   • my_drafts             — assignee = me AND status in (backlog, drafting)
  *   • in_review_queue       — status = in_review (lead's queue)
  *   • editorial_calendar    — calendar view on publish_at
@@ -42,6 +43,7 @@ export const PieceViews = defineView({
     },
     tabs: [
       { name: 'all', label: 'All Pieces', view: 'all_pieces', isDefault: true, pinned: true },
+      { name: 'my_pieces', label: 'My Pieces', icon: 'user', view: 'my_pieces' },
       { name: 'my_drafts', label: 'My Drafts', icon: 'pen-tool', view: 'my_drafts' },
       { name: 'in_review', label: 'In Review', icon: 'check-circle', view: 'in_review_queue' },
       { name: 'calendar', label: 'Calendar', icon: 'calendar', view: 'editorial_calendar' },
@@ -107,6 +109,44 @@ export const PieceViews = defineView({
       filter: [
         { field: 'assignee', operator: 'equals', value: '{current_user_id}' },
         { field: 'status', operator: 'in', value: ['backlog', 'drafting'] },
+      ],
+      sort: [{ field: 'publish_at', order: 'asc' }],
+    },
+
+    // My Pieces — faithful migration of the former `my_pieces_table` dashboard
+    // widget (ADR-0017): the writer's full active queue across every in-flight
+    // status, sorted by publish date.
+    //
+    // INTENDED semantics of the original widget were:
+    //   (assignee == me OR assignee IS NULL)
+    //   AND status IN (backlog, drafting, in_review, approved, scheduled)
+    // i.e. pieces assigned to me PLUS unclaimed pieces I could pick up.
+    //
+    // LIMITATION — the OR branch cannot be expressed. ListView `filter` is a
+    // flat array of { field, operator, value } rules combined with AND only;
+    // ViewFilterRule is `additionalProperties: false` (no nested and/or group)
+    // and the spec exposes no disjunction operator (confirmed against
+    // @objectstack/spec 9.0.0: json-schema/ui/ViewFilterRule.json and the
+    // view.zod filter type). There is therefore no supported way to union
+    // "assignee == me" with "assignee IS NULL" inside a single view.
+    //
+    // FAITHFUL DEGRADATION — we keep the dominant intent (the pieces that are
+    // actually mine) and drop the unassigned-pickup branch. This matches the
+    // repo convention already used by `my_drafts` (assignee == current user).
+    // The status set is reproduced exactly.
+    my_pieces: {
+      name: 'my_pieces',
+      type: 'grid',
+      label: 'My Pieces',
+      data: { provider: 'object', object: 'content_piece' },
+      columns: ['title', 'status', 'format', 'publish_at'],
+      filter: [
+        { field: 'assignee', operator: 'equals', value: '{current_user_id}' },
+        {
+          field: 'status',
+          operator: 'in',
+          value: ['backlog', 'drafting', 'in_review', 'approved', 'scheduled'],
+        },
       ],
       sort: [{ field: 'publish_at', order: 'asc' }],
     },

--- a/packages/hr/src/views/hr_time_off_request.view.ts
+++ b/packages/hr/src/views/hr_time_off_request.view.ts
@@ -32,6 +32,12 @@ export const TimeOffRequestViews = defineView({
         isDefault: true,
         pinned: true,
       },
+      {
+        name: 'my_approvals',
+        label: 'Awaiting My Approval',
+        icon: 'user-check',
+        view: 'my_pending_approvals',
+      },
       { name: 'pipeline', label: 'Approval Pipeline', icon: 'columns', view: 'time_off_pipeline' },
       { name: 'approved', label: 'Approved', icon: 'check', view: 'approved_time_off' },
       { name: 'ooo_today', label: 'Out Today', icon: 'plane', view: 'out_of_office_today' },
@@ -75,6 +81,26 @@ export const TimeOffRequestViews = defineView({
       columns: ['employee', 'leave_type', 'start_date', 'end_date', 'days', 'submitted_at'],
       filter: [{ field: 'status', operator: 'equals', value: 'submitted' }],
       sort: [{ field: 'submitted_at', order: 'asc' }],
+    },
+
+    // Awaiting My Approval — faithful migration of the former
+    // `pending_time_off_table` dashboard widget (ADR-0017): submitted requests
+    // where the current user is the named approver. Unlike `pending_time_off`
+    // (every submitted request), this is scoped to the rows *I* must act on.
+    //
+    // The semantics are pure AND and therefore fully expressible:
+    //   status == 'submitted' AND approver == current user.
+    my_pending_approvals: {
+      name: 'my_pending_approvals',
+      type: 'grid',
+      label: 'Awaiting My Approval',
+      data: { provider: 'object', object: 'hr_time_off_request' },
+      columns: ['employee', 'leave_type', 'start_date', 'end_date', 'days', 'submitted_at'],
+      filter: [
+        { field: 'status', operator: 'equals', value: 'submitted' },
+        { field: 'approver', operator: 'equals', value: '{current_user_id}' },
+      ],
+      sort: [{ field: 'start_date', order: 'asc' }],
     },
     approved_time_off: {
       name: 'approved_time_off',


### PR DESCRIPTION
## Background

[PR #27](https://github.com/objectstack-ai/templates/pull/27) migrated the dashboard record-listing tables to object-bound ListViews (ADR-0017). Two of those migrations shipped with **approximate** filters because the precise semantics were awkward to express. This PR closes both out faithfully.

## Does ListView `filter` support OR / disjunction? — **No.**

Investigated `@objectstack/spec` 9.0.0:

- `json-schema/ui/ViewFilterRule.json` — a rule is `{ field, operator, value }` with **`additionalProperties: false`**. No nested `and`/`or` group, no condition tree.
- `view.zod` (`view.zod-*.d.ts`) — `filter` is typed **everywhere** as `z.ZodOptional<z.ZodArray<{ field, operator, value }>>`. Doc comment: *"declarative array-of-objects format: [{ field, operator, value }]"*. The array is **AND**-combined.
- No `or`-style operator exists in the spec, and there is **zero** OR usage anywhere in the repo's views.

**Conclusion:** disjunction (`A OR B`) cannot be expressed in a ListView filter. Pure-AND conditions are fully expressible.

## Changes

### (1) content — `my_pieces` ("My Pieces" tab)
Restores the former `my_pieces_table` widget.

- **Intended:** `(assignee == me OR assignee IS NULL) AND status IN (backlog, drafting, in_review, approved, scheduled)`
- **Limitation:** the `OR assignee IS NULL` (unclaimed-pickup) branch is **unrepresentable** — see above.
- **Faithful degradation:** `assignee == me AND status IN (...)`. Drops only the unassigned branch; the status set is reproduced exactly. Matches the existing `my_drafts` convention (`assignee == current user`). The limitation is documented inline in the view file.
- columns `['title','status','format','publish_at']`, sort `publish_at` asc.

### (2) hr — `my_pending_approvals` ("Awaiting My Approval" tab)
Restores the former `pending_time_off_table` widget.

- **Filter:** `status == 'submitted' AND approver == current user` — pure AND, **reproduced exactly**.
- Distinct from the existing **Pending** tab, which shows *all* submitted requests.
- columns `['employee','leave_type','start_date','end_date','days','submitted_at']`, sort `start_date` asc.

## Verification

All pass:
- `pnpm -r --filter='!@objectlab/all' run build`
- `pnpm --filter @objectlab/all run clean && pnpm --filter @objectlab/all run compile`
- `pnpm -r run typecheck`

Both new tabs' `view:` references resolve to real listView names (`my_pieces`, `my_pending_approvals`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)