### PR TITLE
fix(ui): repair dashboard chart bindings after ADR-0021 cutover

### DIFF
--- a/packages/compliance/src/dashboards/control_posture.dashboard.ts
+++ b/packages/compliance/src/dashboards/control_posture.dashboard.ts
@@ -104,7 +104,9 @@ export const ControlPostureDashboard: Dashboard = {
       chartConfig: {
         type: 'line',
         xAxis: { field: 'assessed_at', format: '%b %Y', showGridLines: true, logarithmic: false },
-        yAxis: [{ field: 'value', format: '0,0', showGridLines: true, logarithmic: false }],
+        yAxis: [
+          { field: 'assessment_count', format: '0,0', showGridLines: true, logarithmic: false },
+        ],
         showLegend: true,
         showDataLabels: false,
       },

--- a/packages/content/src/dashboards/editorial_calendar.dashboard.ts
+++ b/packages/content/src/dashboards/editorial_calendar.dashboard.ts
@@ -92,6 +92,13 @@ export const EditorialCalendarDashboard: Dashboard = {
       values: ['publication_count'],
       title: 'Publications by Channel (30d)',
       type: 'pie',
+      chartConfig: {
+        type: 'pie',
+        xAxis: { field: 'channel', showGridLines: false, logarithmic: false },
+        yAxis: [{ field: 'publication_count', showGridLines: true, logarithmic: false }],
+        showLegend: true,
+        showDataLabels: false,
+      },
       filter: { published_at: { $gte: '{last_month_start}' } },
       layout: { x: 8, y: 2, w: 4, h: 6 },
       options: { donut: true, legend: 'right' },
@@ -111,7 +118,7 @@ export const EditorialCalendarDashboard: Dashboard = {
       chartConfig: {
         type: 'line',
         xAxis: { field: 'published_at', format: '%b %Y', showGridLines: true, logarithmic: false },
-        yAxis: [{ field: 'value', format: '0,0', showGridLines: true, logarithmic: false }],
+        yAxis: [{ field: 'piece_count', format: '0,0', showGridLines: true, logarithmic: false }],
         showLegend: true,
         showDataLabels: false,
       },

--- a/packages/content/src/dashboards/roi_by_channel.dashboard.ts
+++ b/packages/content/src/dashboards/roi_by_channel.dashboard.ts
@@ -86,6 +86,15 @@ export const RoiByChannelDashboard: Dashboard = {
       values: ['sum_total_views'],
       title: 'Views by Channel (90d)',
       type: 'bar',
+      chartConfig: {
+        type: 'bar',
+        xAxis: { field: 'channel', showGridLines: false, logarithmic: false },
+        yAxis: [
+          { field: 'sum_total_views', format: '0,0', showGridLines: true, logarithmic: false },
+        ],
+        showLegend: false,
+        showDataLabels: false,
+      },
       filter: { published_at: { $gte: '{90_days_ago}' } },
       compareTo: 'previousPeriod',
       layout: { x: 0, y: 2, w: 6, h: 5 },
@@ -103,7 +112,7 @@ export const RoiByChannelDashboard: Dashboard = {
       chartConfig: {
         type: 'line',
         xAxis: { field: 'period_start', format: '%b %d', showGridLines: true, logarithmic: false },
-        yAxis: [{ field: 'signups', format: '0,0', showGridLines: true, logarithmic: false }],
+        yAxis: [{ field: 'sum_signups', format: '0,0', showGridLines: true, logarithmic: false }],
         showLegend: true,
         showDataLabels: false,
       },

--- a/packages/contracts/src/dashboards/renewals_at_risk.dashboard.ts
+++ b/packages/contracts/src/dashboards/renewals_at_risk.dashboard.ts
@@ -103,7 +103,9 @@ export const RenewalsAtRiskDashboard: Dashboard = {
       chartConfig: {
         type: 'line',
         xAxis: { field: 'signed_date', format: '%b %Y', showGridLines: true, logarithmic: false },
-        yAxis: [{ field: 'value', format: '0,0', showGridLines: true, logarithmic: false }],
+        yAxis: [
+          { field: 'contract_count', format: '0,0', showGridLines: true, logarithmic: false },
+        ],
         showLegend: true,
         showDataLabels: false,
       },

--- a/packages/expense/src/dashboards/expenses_overview.dashboard.ts
+++ b/packages/expense/src/dashboards/expenses_overview.dashboard.ts
@@ -88,7 +88,7 @@ export const ExpensesOverviewDashboard: Dashboard = {
       chartConfig: {
         type: 'bar',
         xAxis: { field: 'category', showGridLines: false, logarithmic: false },
-        yAxis: [{ field: 'amount', format: '$0,0', showGridLines: true, logarithmic: false }],
+        yAxis: [{ field: 'sum_amount', format: '$0,0', showGridLines: true, logarithmic: false }],
         showLegend: false,
         showDataLabels: false,
       },
@@ -105,7 +105,9 @@ export const ExpensesOverviewDashboard: Dashboard = {
       chartConfig: {
         type: 'line',
         xAxis: { field: 'reimbursed_at', format: '%b %Y', showGridLines: true, logarithmic: false },
-        yAxis: [{ field: 'total_amount', format: '$0,0', showGridLines: true, logarithmic: false }],
+        yAxis: [
+          { field: 'sum_total_amount', format: '$0,0', showGridLines: true, logarithmic: false },
+        ],
         showLegend: true,
         showDataLabels: false,
       },

--- a/packages/helpdesk/src/dashboards/manager_overview.dashboard.ts
+++ b/packages/helpdesk/src/dashboards/manager_overview.dashboard.ts
@@ -83,6 +83,13 @@ export const ManagerOverviewDashboard: Dashboard = {
       values: ['ticket_count'],
       title: 'Tickets by Status',
       type: 'bar',
+      chartConfig: {
+        type: 'bar',
+        xAxis: { field: 'status', showGridLines: false, logarithmic: false },
+        yAxis: [{ field: 'ticket_count', format: '0,0', showGridLines: true, logarithmic: false }],
+        showLegend: false,
+        showDataLabels: false,
+      },
       layout: { x: 0, y: 2, w: 6, h: 4 },
     },
     {
@@ -92,6 +99,13 @@ export const ManagerOverviewDashboard: Dashboard = {
       values: ['ticket_count'],
       title: 'Sentiment Distribution',
       type: 'pie',
+      chartConfig: {
+        type: 'pie',
+        xAxis: { field: 'ai_sentiment', showGridLines: false, logarithmic: false },
+        yAxis: [{ field: 'ticket_count', showGridLines: true, logarithmic: false }],
+        showLegend: true,
+        showDataLabels: false,
+      },
       filter: { status: { $nin: ['closed'] } },
       layout: { x: 6, y: 2, w: 6, h: 4 },
     },
@@ -103,6 +117,13 @@ export const ManagerOverviewDashboard: Dashboard = {
       values: ['ticket_count'],
       title: 'AI Category Mix',
       type: 'bar',
+      chartConfig: {
+        type: 'bar',
+        xAxis: { field: 'ai_category', showGridLines: false, logarithmic: false },
+        yAxis: [{ field: 'ticket_count', format: '0,0', showGridLines: true, logarithmic: false }],
+        showLegend: false,
+        showDataLabels: false,
+      },
       layout: { x: 0, y: 6, w: 6, h: 4 },
     },
     {
@@ -112,6 +133,13 @@ export const ManagerOverviewDashboard: Dashboard = {
       values: ['ticket_count'],
       title: 'Volume by Channel',
       type: 'bar',
+      chartConfig: {
+        type: 'bar',
+        xAxis: { field: 'channel', showGridLines: false, logarithmic: false },
+        yAxis: [{ field: 'ticket_count', format: '0,0', showGridLines: true, logarithmic: false }],
+        showLegend: false,
+        showDataLabels: false,
+      },
       layout: { x: 6, y: 6, w: 6, h: 4 },
     },
 
@@ -132,7 +160,7 @@ export const ManagerOverviewDashboard: Dashboard = {
       chartConfig: {
         type: 'line',
         xAxis: { field: 'resolved_at', format: '%b %d', showGridLines: true, logarithmic: false },
-        yAxis: [{ field: 'value', format: '0,0', showGridLines: true, logarithmic: false }],
+        yAxis: [{ field: 'ticket_count', format: '0,0', showGridLines: true, logarithmic: false }],
         showLegend: true,
         showDataLabels: false,
       },

--- a/packages/hr/src/dashboards/hr_admin.dashboard.ts
+++ b/packages/hr/src/dashboards/hr_admin.dashboard.ts
@@ -106,6 +106,15 @@ export const HrAdminDashboard: Dashboard = {
       values: ['employee_count'],
       title: 'Headcount by Department',
       type: 'bar',
+      chartConfig: {
+        type: 'bar',
+        xAxis: { field: 'department', showGridLines: false, logarithmic: false },
+        yAxis: [
+          { field: 'employee_count', format: '0,0', showGridLines: true, logarithmic: false },
+        ],
+        showLegend: false,
+        showDataLabels: false,
+      },
       filter: { status: { $ne: 'terminated' } },
       layout: { x: 0, y: 4, w: 6, h: 4 },
     },
@@ -125,7 +134,9 @@ export const HrAdminDashboard: Dashboard = {
       chartConfig: {
         type: 'line',
         xAxis: { field: 'hire_date', format: '%b %Y', showGridLines: true, logarithmic: false },
-        yAxis: [{ field: 'value', format: '0,0', showGridLines: true, logarithmic: false }],
+        yAxis: [
+          { field: 'employee_count', format: '0,0', showGridLines: true, logarithmic: false },
+        ],
         showLegend: true,
         showDataLabels: false,
       },

--- a/packages/procurement/src/dashboards/spend_at_a_glance.dashboard.ts
+++ b/packages/procurement/src/dashboards/spend_at_a_glance.dashboard.ts
@@ -95,7 +95,9 @@ export const SpendAtAGlanceDashboard: Dashboard = {
       chartConfig: {
         type: 'line',
         xAxis: { field: 'order_date', format: '%b %Y', showGridLines: true, logarithmic: false },
-        yAxis: [{ field: 'total_amount', format: '$0,0', showGridLines: true, logarithmic: false }],
+        yAxis: [
+          { field: 'sum_total_amount', format: '$0,0', showGridLines: true, logarithmic: false },
+        ],
         showLegend: true,
         showDataLabels: false,
       },

--- a/packages/todo/src/dashboards/my_work.dashboard.ts
+++ b/packages/todo/src/dashboards/my_work.dashboard.ts
@@ -87,7 +87,7 @@ export const MyWorkDashboard: Dashboard = {
       chartConfig: {
         type: 'line',
         xAxis: { field: 'completed_at', format: '%b %d', showGridLines: true, logarithmic: false },
-        yAxis: [{ field: 'value', format: '0,0', showGridLines: true, logarithmic: false }],
+        yAxis: [{ field: 'task_count', format: '0,0', showGridLines: true, logarithmic: false }],
         showLegend: true,
         showDataLabels: false,
       },


### PR DESCRIPTION
## Summary

Follow-up to #27. While verifying the dashboards in the browser, found that **17 chart widgets across all 11 dashboards rendered empty** (axis labels present, no data series) even when the underlying data existed — a separate defect from the same ADR-0021 single-form cutover.

**Root cause:** the cutover made chart data come back keyed by the dataset **measure name** (`sum_amount`, `ticket_count`, …), but each chart's `chartConfig` axis fields still referenced the **old raw field name**. Field mismatch → no series plotted. `objectstack build` / `validate` pass because the axis `field` is just a string with no requirement to resolve to a real measure.

Two forms:
- **10 widgets** — `chartConfig.yAxis[].field` pointed at the old field (`amount`, `total_amount`, `signups`) or placeholder (`value`). Repointed to the measure in `values[]`.
- **7 widgets** (helpdesk `tickets_by_*`, content channel charts, hr `headcount_by_dept`) — **no `chartConfig` at all**. Added one mapping `xAxis.field`=dimension, `yAxis.field`=measure.

KPI/metric widgets were unaffected; ListView record tables were already migrated in #27. Only grouped charts were broken.

## Verification

- ✅ Static binding audit: **0/17 broken** (was 17/17)
- ✅ All apps build + marketplace compile clean; workspace typecheck passes
- ✅ **Browser sweep of all 11 dashboards** (logged into the console): charts now render real bars/lines/pies wherever the seed has data in-window — helpdesk (Tickets by Status bars + Sentiment pie), hr (Headcount by Dept bars + Hires line), expense (Spend by Category bars), contracts/content (lines).
- ℹ️ Remaining "No rows" panels (compliance assessments, content ROI/channel-mix, procurement PO-by-month, todo throughput) are **genuine empty-data states** — their KPI metrics on the same dataset are also empty / user-scoped to zero — not binding errors.

## Related

- Builds on #27 (table → ListView migration).
- A framework issue is being filed proposing build-time **dashboard reference-integrity validation** (verify `dataset`/`dimensions`/`values` and `chartConfig` axis fields resolve to real dataset members) so both this bug and the #27 table bug fail fast at build time instead of silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)