### PR TITLE
fix(flows): repair PR→PO conversion and content trigger conditions (runtime-verified)

### DIFF
--- a/packages/content/src/flows/cta_creation_default.flow.ts
+++ b/packages/content/src/flows/cta_creation_default.flow.ts
@@ -28,7 +28,13 @@ export const CtaCreationDefaultFlow: Flow = {
       config: {
         objectName: 'content_piece',
         triggerType: 'record-after-create',
-        condition: '!isBlank(record.target_channels)',
+        // Supported operator (`!= null`) instead of isBlank(), which the
+        // runtime condition dialect does not evaluate. NOTE: `target_channels`
+        // is a multi-lookup (junction table), so it is not present on the
+        // after-create record row the condition sees — this flow therefore
+        // still won't fire until a fork promotes the channel link onto the
+        // piece or triggers off the junction. Single-channel forks work today.
+        condition: 'record.target_channels != null',
       },
     },
     {

--- a/packages/content/src/flows/signal_to_topic_promotion.flow.ts
+++ b/packages/content/src/flows/signal_to_topic_promotion.flow.ts
@@ -28,7 +28,10 @@ export const SignalToTopicPromotionFlow: Flow = {
       config: {
         objectName: 'content_signal',
         triggerType: 'record-after-update',
-        condition: 'status == "promoted" && PRIOR(status) != "promoted"',
+        // Use `previous.status` (the proven record-change idiom) — PRIOR() is
+        // not evaluated by the runtime condition dialect, which silently
+        // skipped this flow so promotions never created a topic.
+        condition: 'status == "promoted" && previous.status != "promoted"',
       },
     },
     {

--- a/packages/procurement/src/flows/pr_to_po_convert.flow.ts
+++ b/packages/procurement/src/flows/pr_to_po_convert.flow.ts
@@ -57,7 +57,11 @@ export const PRToPOConvertFlow: Flow = {
           total_amount: '{pr.estimated_amount}',
           received_amount: 0,
           cost_center: '{pr.cost_center}',
-          order_date: 'today()',
+          // order_date is intentionally left unset on the draft PO — the buyer
+          // sets it when sending (enforced by `sent_requires_order_date`). A
+          // literal 'today()' string is not a valid date and the runtime's
+          // date validation rejects it, which previously aborted the whole
+          // PR→PO conversion.
           expected_delivery: '{pr.needed_by}',
           notes:
             'Auto-generated from PR {pr.request_number} ({pr.title}). Review line items before sending.',

--- a/packages/procurement/src/objects/procurement_order.object.ts
+++ b/packages/procurement/src/objects/procurement_order.object.ts
@@ -106,8 +106,10 @@ export const PurchaseOrder = ObjectSchema.create({
     }),
     order_date: Field.date({
       label: 'Order Date',
-      required: true,
+      required: false,
       group: 'fulfillment',
+      description:
+        'Set when the PO is sent to the vendor. Not required on a draft (a PR→PO conversion creates a draft without one); the `sent_requires_order_date` validation enforces it at send time.',
     }),
     expected_delivery: Field.date({
       label: 'Expected Delivery',


### PR DESCRIPTION
## Why
Ran a comprehensive runtime test harness against `objectstack dev all` (9.5.1), logging in as the seed admin and **triggering every flow / state machine, asserting the actual side effects** (not just screenshots). Result: **19 PASS**, plus these real defects in flows that build cleanly but don't execute correctly:

1. **procurement `pr_to_po_convert`** created the PO with `order_date: 'today()'` — a literal string the runtime rejects (`invalid_date`), aborting the whole conversion (no PO; PR stuck at `approved`). Fix: `order_date` is optional on a draft PO (buyer sets it at send; `sent_requires_order_date` still enforces it), and drop the bogus literal. **Verified:** approving a PR now creates a draft PO, flips PR→converted, carries `cost_center`.
2. **content `signal_to_topic_promotion`** used `PRIOR(status)` and **`cta_creation_default`** used `isBlank(...)` — neither is evaluated by the runtime condition dialect, so both flows were silently skipped. Switched to the proven `previous.status` / `!= null` idioms. **Verified:** promoting a signal now creates a topic.

## Documented (not regressions, left as fork points)
- `cta_creation_default` still no-ops: `target_channels` is a multi-lookup (junction), not on the after-create row the condition sees — noted inline.
- `publication_rollup`'s aggregate node is a runtime no-op (in-flow aggregation unsupported), so totals stay seed-maintained per CHARTER.
- todo urgent-due validation fires on update + explicit-null (the UI path) but not on raw-API field *omit* — a platform CEL quirk identical to the pre-existing compliance rule.

## Verification
17→**19 PASS** harness (hooks, state machines, contracts/hr/procurement/helpdesk/content flows, validations). `typecheck` + `objectstack build` (9/9) + `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)