### PR TITLE
fix(flows): double-brace interpolation in project notify nodes (#1315)

### DIFF
--- a/packages/project/src/flows/daily_ai_risk_assessment.flow.ts
+++ b/packages/project/src/flows/daily_ai_risk_assessment.flow.ts
@@ -100,7 +100,7 @@ export const DailyAIRiskAssessmentFlow: Flow = {
       label: 'Notify PMO of High Risk',
       config: {
         to: 'pmo_team',
-        message: 'Project {{project.name}} has high risk score: {{project.ai_risk_score}}',
+        message: 'Project {project.name} has high risk score: {project.ai_risk_score}',
       },
     },
     {

--- a/packages/project/src/flows/milestone_deadline_warning.flow.ts
+++ b/packages/project/src/flows/milestone_deadline_warning.flow.ts
@@ -75,7 +75,7 @@ export const MilestoneDeadlineWarningFlow: Flow = {
       label: 'Escalate to PMO',
       config: {
         to: 'pmo_team',
-        message: 'OVERDUE: Milestone "{{milestone.name}}" in project {{milestone.project.name}}',
+        message: 'OVERDUE: Milestone "{milestone.name}" in project {milestone.project.name}',
       },
     },
     {

--- a/packages/project/src/flows/resource_conflict_detection.flow.ts
+++ b/packages/project/src/flows/resource_conflict_detection.flow.ts
@@ -92,7 +92,7 @@ export const ResourceConflictDetectionFlow: Flow = {
       config: {
         to: '{affectedProjects[*].project_manager}',
         message:
-          'Resource conflict: {{resource.person.name}} is allocated {{totalHours}} hours/week across multiple projects.',
+          'Resource conflict: {resource.person.name} is allocated {totalHours} hours/week across multiple projects.',
       },
     },
     {


### PR DESCRIPTION
Flow node **values** interpolate with **single** braces (`{x}`); the project flows' notify `message`/`title` used double-brace `{{x}}` — that's the formula/template-field dialect and renders literal braces around the value at runtime.

- `project/daily_ai_risk_assessment`, `project/milestone_deadline_warning`, `project/resource_conflict_detection` → `{{x}}` → `{x}`.

`@objectlab/project` builds clean.

> The #1877 `PRIOR()` → `previous.status` fix for `content/signal_to_topic_promotion` was already landed on `main` by #44 — dropped from this PR on rebase. Remaining A-class items (#1874 schedule+range restructure, #1870 invoke_function data-access) are larger/design-sensitive — separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)