### PR TITLE
chore(deps): upgrade @objectstack to 9.9.1

### DIFF
--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -12,10 +12,10 @@
     "clean": "rm -rf .objectstack/marketplace-packages dist"
   },
   "dependencies": {
-    "@objectstack/account": "^9.8.0",
-    "@objectstack/cli": "^9.8.0",
-    "@objectstack/driver-sqlite-wasm": "^9.8.0",
-    "@objectstack/runtime": "^9.8.0",
+    "@objectstack/account": "^9.9.1",
+    "@objectstack/cli": "^9.9.1",
+    "@objectstack/driver-sqlite-wasm": "^9.9.1",
+    "@objectstack/runtime": "^9.9.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^9.8.0",
-    "@objectstack/cli": "^9.8.0",
-    "@objectstack/driver-memory": "^9.8.0",
-    "@objectstack/driver-sql": "^9.8.0",
-    "@objectstack/driver-sqlite-wasm": "^9.8.0",
-    "@objectstack/metadata": "^9.8.0",
-    "@objectstack/objectql": "^9.8.0",
-    "@objectstack/runtime": "^9.8.0",
-    "@objectstack/service-analytics": "^9.8.0",
-    "@objectstack/service-automation": "^9.8.0",
-    "@objectstack/spec": "^9.8.0",
+    "@objectstack/account": "^9.9.1",
+    "@objectstack/cli": "^9.9.1",
+    "@objectstack/driver-memory": "^9.9.1",
+    "@objectstack/driver-sql": "^9.9.1",
+    "@objectstack/driver-sqlite-wasm": "^9.9.1",
+    "@objectstack/metadata": "^9.9.1",
+    "@objectstack/objectql": "^9.9.1",
+    "@objectstack/runtime": "^9.9.1",
+    "@objectstack/service-analytics": "^9.9.1",
+    "@objectstack/service-automation": "^9.9.1",
+    "@objectstack/spec": "^9.9.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^9.8.0",
-    "@objectstack/cli": "^9.8.0",
-    "@objectstack/driver-memory": "^9.8.0",
-    "@objectstack/driver-sql": "^9.8.0",
-    "@objectstack/driver-sqlite-wasm": "^9.8.0",
-    "@objectstack/metadata": "^9.8.0",
-    "@objectstack/objectql": "^9.8.0",
-    "@objectstack/runtime": "^9.8.0",
-    "@objectstack/service-analytics": "^9.8.0",
-    "@objectstack/service-automation": "^9.8.0",
-    "@objectstack/spec": "^9.8.0",
+    "@objectstack/account": "^9.9.1",
+    "@objectstack/cli": "^9.9.1",
+    "@objectstack/driver-memory": "^9.9.1",
+    "@objectstack/driver-sql": "^9.9.1",
+    "@objectstack/driver-sqlite-wasm": "^9.9.1",
+    "@objectstack/metadata": "^9.9.1",
+    "@objectstack/objectql": "^9.9.1",
+    "@objectstack/runtime": "^9.9.1",
+    "@objectstack/service-analytics": "^9.9.1",
+    "@objectstack/service-automation": "^9.9.1",
+    "@objectstack/spec": "^9.9.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^9.8.0",
-    "@objectstack/cli": "^9.8.0",
-    "@objectstack/driver-memory": "^9.8.0",
-    "@objectstack/driver-sql": "^9.8.0",
-    "@objectstack/driver-sqlite-wasm": "^9.8.0",
-    "@objectstack/metadata": "^9.8.0",
-    "@objectstack/objectql": "^9.8.0",
-    "@objectstack/runtime": "^9.8.0",
-    "@objectstack/service-analytics": "^9.8.0",
-    "@objectstack/service-automation": "^9.8.0",
-    "@objectstack/spec": "^9.8.0",
+    "@objectstack/account": "^9.9.1",
+    "@objectstack/cli": "^9.9.1",
+    "@objectstack/driver-memory": "^9.9.1",
+    "@objectstack/driver-sql": "^9.9.1",
+    "@objectstack/driver-sqlite-wasm": "^9.9.1",
+    "@objectstack/metadata": "^9.9.1",
+    "@objectstack/objectql": "^9.9.1",
+    "@objectstack/runtime": "^9.9.1",
+    "@objectstack/service-analytics": "^9.9.1",
+    "@objectstack/service-automation": "^9.9.1",
+    "@objectstack/spec": "^9.9.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/expense/package.json
+++ b/packages/expense/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^9.8.0",
-    "@objectstack/cli": "^9.8.0",
-    "@objectstack/driver-memory": "^9.8.0",
-    "@objectstack/driver-sql": "^9.8.0",
-    "@objectstack/driver-sqlite-wasm": "^9.8.0",
-    "@objectstack/metadata": "^9.8.0",
-    "@objectstack/objectql": "^9.8.0",
-    "@objectstack/runtime": "^9.8.0",
-    "@objectstack/service-analytics": "^9.8.0",
-    "@objectstack/service-automation": "^9.8.0",
-    "@objectstack/spec": "^9.8.0",
+    "@objectstack/account": "^9.9.1",
+    "@objectstack/cli": "^9.9.1",
+    "@objectstack/driver-memory": "^9.9.1",
+    "@objectstack/driver-sql": "^9.9.1",
+    "@objectstack/driver-sqlite-wasm": "^9.9.1",
+    "@objectstack/metadata": "^9.9.1",
+    "@objectstack/objectql": "^9.9.1",
+    "@objectstack/runtime": "^9.9.1",
+    "@objectstack/service-analytics": "^9.9.1",
+    "@objectstack/service-automation": "^9.9.1",
+    "@objectstack/spec": "^9.9.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/helpdesk/package.json
+++ b/packages/helpdesk/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^9.8.0",
-    "@objectstack/cli": "^9.8.0",
-    "@objectstack/driver-memory": "^9.8.0",
-    "@objectstack/driver-sql": "^9.8.0",
-    "@objectstack/driver-sqlite-wasm": "^9.8.0",
-    "@objectstack/metadata": "^9.8.0",
-    "@objectstack/objectql": "^9.8.0",
-    "@objectstack/runtime": "^9.8.0",
-    "@objectstack/service-analytics": "^9.8.0",
-    "@objectstack/service-automation": "^9.8.0",
-    "@objectstack/spec": "^9.8.0",
+    "@objectstack/account": "^9.9.1",
+    "@objectstack/cli": "^9.9.1",
+    "@objectstack/driver-memory": "^9.9.1",
+    "@objectstack/driver-sql": "^9.9.1",
+    "@objectstack/driver-sqlite-wasm": "^9.9.1",
+    "@objectstack/metadata": "^9.9.1",
+    "@objectstack/objectql": "^9.9.1",
+    "@objectstack/runtime": "^9.9.1",
+    "@objectstack/service-analytics": "^9.9.1",
+    "@objectstack/service-automation": "^9.9.1",
+    "@objectstack/spec": "^9.9.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/hr/package.json
+++ b/packages/hr/package.json
@@ -19,17 +19,17 @@
     "test:qa": "node ../../scripts/run-qa.mjs --url http://localhost:4009 --file qa/business-workflow.test.json"
   },
   "dependencies": {
-    "@objectstack/account": "^9.8.0",
-    "@objectstack/cli": "^9.8.0",
-    "@objectstack/driver-memory": "^9.8.0",
-    "@objectstack/driver-sql": "^9.8.0",
-    "@objectstack/driver-sqlite-wasm": "^9.8.0",
-    "@objectstack/metadata": "^9.8.0",
-    "@objectstack/objectql": "^9.8.0",
-    "@objectstack/runtime": "^9.8.0",
-    "@objectstack/service-analytics": "^9.8.0",
-    "@objectstack/service-automation": "^9.8.0",
-    "@objectstack/spec": "^9.8.0",
+    "@objectstack/account": "^9.9.1",
+    "@objectstack/cli": "^9.9.1",
+    "@objectstack/driver-memory": "^9.9.1",
+    "@objectstack/driver-sql": "^9.9.1",
+    "@objectstack/driver-sqlite-wasm": "^9.9.1",
+    "@objectstack/metadata": "^9.9.1",
+    "@objectstack/objectql": "^9.9.1",
+    "@objectstack/runtime": "^9.9.1",
+    "@objectstack/service-analytics": "^9.9.1",
+    "@objectstack/service-automation": "^9.9.1",
+    "@objectstack/spec": "^9.9.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/procurement/package.json
+++ b/packages/procurement/package.json
@@ -18,17 +18,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^9.8.0",
-    "@objectstack/cli": "^9.8.0",
-    "@objectstack/driver-memory": "^9.8.0",
-    "@objectstack/driver-sql": "^9.8.0",
-    "@objectstack/driver-sqlite-wasm": "^9.8.0",
-    "@objectstack/metadata": "^9.8.0",
-    "@objectstack/objectql": "^9.8.0",
-    "@objectstack/runtime": "^9.8.0",
-    "@objectstack/service-analytics": "^9.8.0",
-    "@objectstack/service-automation": "^9.8.0",
-    "@objectstack/spec": "^9.8.0",
+    "@objectstack/account": "^9.9.1",
+    "@objectstack/cli": "^9.9.1",
+    "@objectstack/driver-memory": "^9.9.1",
+    "@objectstack/driver-sql": "^9.9.1",
+    "@objectstack/driver-sqlite-wasm": "^9.9.1",
+    "@objectstack/metadata": "^9.9.1",
+    "@objectstack/objectql": "^9.9.1",
+    "@objectstack/runtime": "^9.9.1",
+    "@objectstack/service-analytics": "^9.9.1",
+    "@objectstack/service-automation": "^9.9.1",
+    "@objectstack/spec": "^9.9.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -15,17 +15,17 @@
     "test": "objectstack build"
   },
   "dependencies": {
-    "@objectstack/account": "^9.8.0",
-    "@objectstack/cli": "^9.8.0",
-    "@objectstack/driver-memory": "^9.8.0",
-    "@objectstack/driver-sql": "^9.8.0",
-    "@objectstack/driver-sqlite-wasm": "^9.8.0",
-    "@objectstack/metadata": "^9.8.0",
-    "@objectstack/objectql": "^9.8.0",
-    "@objectstack/runtime": "^9.8.0",
-    "@objectstack/service-analytics": "^9.8.0",
-    "@objectstack/service-automation": "^9.8.0",
-    "@objectstack/spec": "^9.8.0",
+    "@objectstack/account": "^9.9.1",
+    "@objectstack/cli": "^9.9.1",
+    "@objectstack/driver-memory": "^9.9.1",
+    "@objectstack/driver-sql": "^9.9.1",
+    "@objectstack/driver-sqlite-wasm": "^9.9.1",
+    "@objectstack/metadata": "^9.9.1",
+    "@objectstack/objectql": "^9.9.1",
+    "@objectstack/runtime": "^9.9.1",
+    "@objectstack/service-analytics": "^9.9.1",
+    "@objectstack/service-automation": "^9.9.1",
+    "@objectstack/spec": "^9.9.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/packages/todo/package.json
+++ b/packages/todo/package.json
@@ -19,17 +19,17 @@
     "test:qa": "node ../../scripts/run-qa.mjs --url http://localhost:4002 --file qa/business-workflow.test.json"
   },
   "dependencies": {
-    "@objectstack/account": "^9.8.0",
-    "@objectstack/cli": "^9.8.0",
-    "@objectstack/driver-memory": "^9.8.0",
-    "@objectstack/driver-sql": "^9.8.0",
-    "@objectstack/driver-sqlite-wasm": "^9.8.0",
-    "@objectstack/metadata": "^9.8.0",
-    "@objectstack/objectql": "^9.8.0",
-    "@objectstack/runtime": "^9.8.0",
-    "@objectstack/service-analytics": "^9.8.0",
-    "@objectstack/service-automation": "^9.8.0",
-    "@objectstack/spec": "^9.8.0",
+    "@objectstack/account": "^9.9.1",
+    "@objectstack/cli": "^9.9.1",
+    "@objectstack/driver-memory": "^9.9.1",
+    "@objectstack/driver-sql": "^9.9.1",
+    "@objectstack/driver-sqlite-wasm": "^9.9.1",
+    "@objectstack/metadata": "^9.9.1",
+    "@objectstack/objectql": "^9.9.1",
+    "@objectstack/runtime": "^9.9.1",
+    "@objectstack/service-analytics": "^9.9.1",
+    "@objectstack/service-automation": "^9.9.1",
+    "@objectstack/spec": "^9.9.1",
     "sql.js": "^1.14.1"
   },
   "optionalDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,17 +18,17 @@ importers:
   packages/all:
     dependencies:
       '@objectstack/account':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/cli':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/runtime':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -40,38 +40,38 @@ importers:
   packages/compliance:
     dependencies:
       '@objectstack/account':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/cli':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -87,38 +87,38 @@ importers:
   packages/content:
     dependencies:
       '@objectstack/account':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/cli':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -134,38 +134,38 @@ importers:
   packages/contracts:
     dependencies:
       '@objectstack/account':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/cli':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -181,38 +181,38 @@ importers:
   packages/expense:
     dependencies:
       '@objectstack/account':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/cli':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -228,38 +228,38 @@ importers:
   packages/helpdesk:
     dependencies:
       '@objectstack/account':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/cli':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -275,38 +275,38 @@ importers:
   packages/hr:
     dependencies:
       '@objectstack/account':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/cli':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -322,38 +322,38 @@ importers:
   packages/procurement:
     dependencies:
       '@objectstack/account':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/cli':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -369,38 +369,38 @@ importers:
   packages/project:
     dependencies:
       '@objectstack/account':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/cli':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -416,38 +416,38 @@ importers:
   packages/todo:
     dependencies:
       '@objectstack/account':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/cli':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/driver-memory':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^9.8.0
-        version: 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^9.9.1
+        version: 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/service-analytics':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^9.8.0
-        version: 9.8.0(ai@6.0.205(zod@4.4.3))
+        specifier: ^9.9.1
+        version: 9.9.1(ai@6.0.205(zod@4.4.3))
       sql.js:
         specifier: ^1.14.1
         version: 1.14.1
@@ -793,36 +793,40 @@ packages:
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
-  '@objectstack/account@9.8.0':
-    resolution: {integrity: sha512-lK7E6CHEmlCNZSh/gSL8BSHypimMFM6RlEte84psV/2SHMSsVXzNqXbiYm6MCwADgtmlxWZVbtCOVYQYnklRYw==}
+  '@objectstack/account@9.9.1':
+    resolution: {integrity: sha512-usrc+UgsdVsmRQGR6se3GJFvV5au26hpiN39q+Gqe9dn2TcOs5vTIR7mUVE64Ww2zmXihONBGNuxXnMwSEsGXw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/cli@9.8.0':
-    resolution: {integrity: sha512-RJEa3zfEdSKcpHwKqUSt9+hoK7aEnpRFS8N0wF+Xskf6CvTHWbgMRWnTjQu6EzqHz3mMCkFMTaLNE1ZvxdI1TA==}
+  '@objectstack/cli@9.9.1':
+    resolution: {integrity: sha512-eDa7pb68uIzZwes52LaesPAY14rjBkCLqRNCCCoQMDBJSOPrmqVkLLRt5TfhcW4IuORHus+tnIUC855WzcPfFA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@objectstack/client@9.8.0':
-    resolution: {integrity: sha512-wLhy81vcUZz9PhWHnlcOvA2KTjHGHW6yIOGdBMYlE/iWms1jqE6jjd0eWK6vRGhyrlzT2txGwRhseYGRxXkyNA==}
+  '@objectstack/client@9.9.1':
+    resolution: {integrity: sha512-P17XjIm9zm+qYs5LDJVOapdbSjoI79CdGdrURNU6yHtpH/xHKw8ewOEileR6WkuIUX6cmZzedWh9eIsq9KUICQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/console@9.8.0':
-    resolution: {integrity: sha512-nig1CaaIm+CLtOpR+hXSIaiiK4FVAFUqmnQRbg1GTSb7WE/jl6eFKN8gY11ojo0hlkJ8pRUhHqqCYMzDqG7u6A==}
-
-  '@objectstack/core@9.8.0':
-    resolution: {integrity: sha512-H+N8rVO/sbgbKIg3eF0NIBW3n90WSgjUIV8cPbf3lxDFdpzaSyD048GT93wgKWhxhtbrVjSxFX+viSbK1QQDtg==}
+  '@objectstack/cloud-connection@9.9.1':
+    resolution: {integrity: sha512-ayTw7HFwdh9jIkrFFmIJ6+urabrN0RAHzL32xmr9SlE4XvB2bSs6FEXweASdzwsgReA5U8Q7y8kV3gAw4eFKFQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-memory@9.8.0':
-    resolution: {integrity: sha512-4cAQtKoziYX3IwoxmbyMAYuZJ2WzN19a34DOP8XZDHQLcJ97OAEFm/hZyzo0ahG4gkWtSToScnpJruo/Dejmsg==}
+  '@objectstack/console@9.9.1':
+    resolution: {integrity: sha512-p8pmcvdCoutG0csH+4mN9UYJTqUt+qa8eP7dnzTSwP3sFA734/qTW8jzKpYvjVNI3B034EnSfzfRHaQ0ntTozg==}
+
+  '@objectstack/core@9.9.1':
+    resolution: {integrity: sha512-jMST2rXNfEsftTZKv/84CLEOtmiZ6uR7P5ETfXxIbLC2zzPtaAy92EDkhzGOSUf9pvLdzEs4qroVgylSgFNCpw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-mongodb@9.8.0':
-    resolution: {integrity: sha512-Jh8fEPg4TcE3Qe6k24Fwob1Z4xWY1atpX5bTHXnO5XkgaqT3XJN4x07+ObZZnCj0wJANHUtSeIm3YRrLvZc3cg==}
+  '@objectstack/driver-memory@9.9.1':
+    resolution: {integrity: sha512-NFHvhiQYDRmCL5TxL0USgNc2Bkvaevo+NFAZnIXCaseTQtAbArYBte7F5gER5Td/UTa6F/fN3r+JeO9wnBupgA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-sql@9.8.0':
-    resolution: {integrity: sha512-hjtPIQPw9/QUpSL/fWFlsnyhgBQIw4mWIOouawVnLSAsNgczb9fpa0W+EXWTcFQRtc9NQ9SwrDHi5QFAorZVVA==}
+  '@objectstack/driver-mongodb@9.9.1':
+    resolution: {integrity: sha512-6x5phl8iHsTbl9apO5B/G8XdK0JaZIAqKt2ui7Ypf0gCYJjgqyHkKD4TUBPK928ASpOisOeWPTPHzmaFVSnC4A==}
+    engines: {node: '>=18.0.0'}
+
+  '@objectstack/driver-sql@9.9.1':
+    resolution: {integrity: sha512-QB8IrFRMno4jiHHPfCMxOI8Tg/RQ4hoF2GszmyxQ0dNSksScHWdKdiFirh9Pr5Mo9WfotCkZH29fkMwcHnOeew==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       mysql2: ^3.0.0
@@ -839,19 +843,19 @@ packages:
       tedious:
         optional: true
 
-  '@objectstack/driver-sqlite-wasm@9.8.0':
-    resolution: {integrity: sha512-DU7SKn+Cjwav7xBLrz/72KaKeoPlUBU13csWDMsLRdSYDSjAeaYx4f4Uwx+1CAI7oRGGnH8E/lhC7yzmqK+FIg==}
+  '@objectstack/driver-sqlite-wasm@9.9.1':
+    resolution: {integrity: sha512-DFYNraBPVu+bVkEomLtSFuFFL93+9nVgUBeRC18Q6jhzFoHzMG78RV+aD3qgBKDm7IP6p94V27oghLv7YUUbtg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/formula@9.8.0':
-    resolution: {integrity: sha512-TRjBTpL95Ac6A+86h4Und2cTxAzxbUrGZpf/7EBGM2eODH/lPocVB/DmSZlIwX86AtNHvzue6kOKBDbJNngeQQ==}
+  '@objectstack/formula@9.9.1':
+    resolution: {integrity: sha512-yvbyWIIj5d5auwCBFCV8JPWgivfIQ+B0ft7SDl5APqNea8xZlWx5g4ZePSR6GMxCPBkqXnQSU5W4udMCr2hp9Q==}
 
-  '@objectstack/mcp@9.8.0':
-    resolution: {integrity: sha512-saUBE+1eSbSn5rggpyIgBW5Fe6XEMGZbvguWTSsyNy4+LLYVPHPlI+J/PJ/2domw7epPNhs/P05qynEioYB2rg==}
+  '@objectstack/mcp@9.9.1':
+    resolution: {integrity: sha512-v8XW04v47ReqDjpFGuhpdpzkD1ecBFWmaqu6nZSS1NZLwENjqfYHC0cDzjFUt3LHpMtkHHSSMYUo8czRL64eTw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/metadata-core@9.8.0':
-    resolution: {integrity: sha512-qRFFLflQhuRehozOb0MX6UB+T3j6pxGi62UWNN6brYJG1xoKj6ue9nVeOA4cz9HFuFnCNiK9xYmY1Kg9zj11mA==}
+  '@objectstack/metadata-core@9.9.1':
+    resolution: {integrity: sha512-onV5W9UZ1ujiPcDicXiPocZERX7rjQkVVkgBFQyxlQXEEztBJUpfNyOLeu47m1GwgWkYr+pienibWIJDYwqxGw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       vitest: ^4.0.0
@@ -859,71 +863,71 @@ packages:
       vitest:
         optional: true
 
-  '@objectstack/metadata-fs@9.8.0':
-    resolution: {integrity: sha512-9pHX8vxIP+qsVShmPHZEprOf3+JfNppbtzmIdwRU0x6ywLYIsBhoQl+fu8Dj5SEkEOc4+IIZX/tRbxLcxJ3zLw==}
+  '@objectstack/metadata-fs@9.9.1':
+    resolution: {integrity: sha512-wVYkVknIfFdPMxb6yKkDYINQpQb2yNvqjn9EPDCqf/6LVUkV2Jj7igs6ZB1enNimrsm/bnw+T+MzHpXL9/V1GQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/metadata@9.8.0':
-    resolution: {integrity: sha512-IqOQ6hk290yUCQk0JGiqcjYPg0d7MbqQcMOQfH2dJJIUNdO//8Bgu0rlsrQvD+rem6Js3U3S2RAH4LzTPBT8gQ==}
+  '@objectstack/metadata@9.9.1':
+    resolution: {integrity: sha512-zf6AqIxv7lxuHHuf+0Mo91p3ViLjAYyybT7nodnFAs3pAqm5ZNcpy0ygaFVy8CrcXIjESwmfW8nzZLiCkFhXIA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/objectql@9.8.0':
-    resolution: {integrity: sha512-QNJGSJ0eQ/v8NuOZstTNM1Y8auMjwAiHN1hAp4MAh/biAC18/8u+nhZHJHyQO4UNgEDvbajrcSWxxn1Yrg7++Q==}
+  '@objectstack/objectql@9.9.1':
+    resolution: {integrity: sha512-eU2ByjPQBiwyUfNDBJ6cIz8JeqJkgm+f09kb6n7F7dPA+gip8+/fNQ2tdIJFV84UReIqrjINiPHtSu2bM8MhTg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/observability@9.8.0':
-    resolution: {integrity: sha512-85B36MeJxU+939AE1QcgJoQma1hKyrR1XrSAxwD/D8UICaKwgOfZ6VJvHxpEad5oAAviV2uCDCsNIYFi8dxFHg==}
+  '@objectstack/observability@9.9.1':
+    resolution: {integrity: sha512-KnJCB0I6d3Ovn9NFuioR/0Fn4TNrobcw1Uq8Z+vwW72Fm+zW7VXSc2F9xfUR1kLUAzIeP53CpGk/D75iUmpyqg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/platform-objects@9.8.0':
-    resolution: {integrity: sha512-eHfRg1UMBIRK+KDhDGROF0Gw1Or4cWe6Nea9iX2/NLyEvA8ErqVoHEDizXqHWA6mKWV8fs24CGyhAVr6SrwJ+g==}
+  '@objectstack/platform-objects@9.9.1':
+    resolution: {integrity: sha512-/8K+lpXKBNnk3sDdBLwoMSKw1ueUe1Bpq6+qOWYqWgdIe0bwh4gLtzuKMssIkz5L8ojJB7fRxVPq/zi96QGVOQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-approvals@9.8.0':
-    resolution: {integrity: sha512-rVtTQzse7MI8hDwEkvCA/KrZLmD7qS/vHmKLHyZFTRygp/qfaF2hdYThcg6aZYwbqD3NRL4SGj/WHc1iGA6ZXA==}
+  '@objectstack/plugin-approvals@9.9.1':
+    resolution: {integrity: sha512-eHt/QZO39ea2YAq9cef4GA63aAmhXkKFtp4kwqeZzwwVoLH5JN0e+TJ3iZHq4NuUydNU7IRiLDp9IdbJLI9s9w==}
 
-  '@objectstack/plugin-audit@9.8.0':
-    resolution: {integrity: sha512-znMJ3R0fa/u4tOCb5ZoAvOs0bpyOx5+uHgFl1qeCbarfy6V775mgsNoGNiOq1F4hvBWElRmDPVaTWxYMYZtqkw==}
+  '@objectstack/plugin-audit@9.9.1':
+    resolution: {integrity: sha512-ZCLs/FU9F/J3dwwqqcl/Rfz0uGrG2mqcmt+4t9ZtV4o+LlZBCao4XjRUhZ3pLYXb50HeCFMiQ8WiEURRpmCzCw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-auth@9.8.0':
-    resolution: {integrity: sha512-L9fnhvGufKqxJcHEkc3O5rQLTNi20mHxYsWb0b8KjzvMhNjMI53xwauerGpZ/+UosGRc50oZatjCS3F4PF473w==}
+  '@objectstack/plugin-auth@9.9.1':
+    resolution: {integrity: sha512-Ph2a6ijL6LU3Ewwi6KExxjUaDo3u6KdaU02JhTDsovodFrFUXc8fqksWW4ErQSHKvRhsbaa93Zn9QObn58oXLA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-email@9.8.0':
-    resolution: {integrity: sha512-tcuSBdwZdk3gLtlMOndzuEJgg68iZNO+CeZGnMQ/I7aqsWAbj+A3O71VpqHXcR+4UELz/kZ++xB4tpw334xUwA==}
+  '@objectstack/plugin-email@9.9.1':
+    resolution: {integrity: sha512-sBbBm/QmcTVjXuqOETpxnntNJ+87/SnHJ9k+I8LD2epJOXvn7TN9e6AMsdpKsiwrMgOyVrOzvI483k0eZrvYIw==}
 
-  '@objectstack/plugin-hono-server@9.8.0':
-    resolution: {integrity: sha512-uBTtkJB3ilkh3u9DLlGD7edZPmaHEpY0w8UQP1KICzg3judOSj9+joHxEOSe9lCfFcoc46yfc3DCtg0a7bDx7Q==}
+  '@objectstack/plugin-hono-server@9.9.1':
+    resolution: {integrity: sha512-a7SuyZJYqgaoVV9CHy/vLM5fySpwNYoq4McvXfWxSobgT5XFH0BfCIaXDXyu1ENjx/1zjDFcuQ664kRaK1fYgA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-org-scoping@9.8.0':
-    resolution: {integrity: sha512-uuufC9vfX+qwlgNp0s9R4ztxTq+axXOk44ZbaeKsOoVDpIYmrLruCAcfsc8gRS2BiZUcY9Z8QLCl7Z5sGOnscA==}
+  '@objectstack/plugin-org-scoping@9.9.1':
+    resolution: {integrity: sha512-VxXRfDvPmp9NhAqHm9e+EsiNKHHqp6Ldj8H4GLpZ7HQ/VIEn+tMvRhZD10YB0ERl3K13H8svG8yrqNUF3pIMQg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-reports@9.8.0':
-    resolution: {integrity: sha512-N5t9Uh8ayM9Jj895ifM11zrf1zuVSGLHKLIBhGMaqiRNrwRZaNa8XlnjPlFPjPEaIy5PECQ1VBrBkTxZvNljwg==}
+  '@objectstack/plugin-reports@9.9.1':
+    resolution: {integrity: sha512-EP4rr15nuBGsPbgcEQ8ZXAKEsFZToPW+R7DRNdOVV1SO1x6sbXmlMso0bNKtYMYiQkA2Q5H2kVyrSIyj7IO0ug==}
 
-  '@objectstack/plugin-security@9.8.0':
-    resolution: {integrity: sha512-mKGQB6hk6APLbJcHDMnlcoYdA8IhPoRTNIEsH+pMsSEiQrqEH+g11eREW8BZ2M0BzdwgPLTkdaZk/pOaKaqZvw==}
+  '@objectstack/plugin-security@9.9.1':
+    resolution: {integrity: sha512-VQbTC5R8J8mlQd78pNG/Xe6ubty5eQ0xZEglXflx8r86JU2EkvPsVwLzg/jJsLFSEBwfehmvYKk/rnvY/17onw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-sharing@9.8.0':
-    resolution: {integrity: sha512-PavxWTWGq+FMxPWc5PsIPO850JPVKr+arCNYxv4VYZOOMMLeMQ4e4I8LPA9ykCy1DNOU3KRHsQkyPZ2IEmyfaw==}
+  '@objectstack/plugin-sharing@9.9.1':
+    resolution: {integrity: sha512-TnCnHS2zTNIfH39bzjxBZol7978LJsbvgQTuvJDheSmVOieM5hlA+H/tjHsa4ii1z8FRH0xNoz4JfGq8Bq7BKw==}
 
-  '@objectstack/plugin-webhooks@9.8.0':
-    resolution: {integrity: sha512-2fnMWv0CgazXV+cXtxoZZ0MUvi5F1WAQdHaGZCXMNxqKuTcVBXGgx/nQjIQOoAqXI73WCCLP88bhqF8kIeCtwQ==}
+  '@objectstack/plugin-webhooks@9.9.1':
+    resolution: {integrity: sha512-lsqy+OqjG42gpT088JEYqswIviGDK6SNteeFBrwtMiKe8j39NbL5pWdeRJRQn2hO3DAtASeHWeSNZSahI2CtPg==}
 
-  '@objectstack/rest@9.8.0':
-    resolution: {integrity: sha512-hqFJf1rLyx2rLrXxDoMvA87qELITQr9GQ8egfCLG4KZP+k6RncJ9VGaUammL4vQf/asm7J2DcRaee8scP3WDIA==}
+  '@objectstack/rest@9.9.1':
+    resolution: {integrity: sha512-ywy6W96RJ1zoDzJRUjfQdwcaoZ8xOd8baVg/v6kinAHWhbZV5ia5UoksjGhBJ77PucCAH634wImkMsfBayx+AQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/runtime@9.8.0':
-    resolution: {integrity: sha512-wD1giXJ+h5g++AsAmAu/gmNjB7wgFhNS6l4DhftR+zbgKUaaYiZRykwXm89t2l0s0FqFSq1DUz8YDdqoWuHTdA==}
+  '@objectstack/runtime@9.9.1':
+    resolution: {integrity: sha512-GtJV1st9L2IhlehMrWbqcVYqwSeX/LUpQFgQwQxyoLcbFYUKwa1Un7VDnf+bkSJZYg/gxT25mqM7LoOOA7HpDg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-ai@9.8.0':
-    resolution: {integrity: sha512-7fmxlVWbrLjBEc157For/2niURhQzOExX2sqm09Fq3+7lU6XodlmxLDP5yi3jqd2DKON5j5sAZ6tacNv3yJfQQ==}
+  '@objectstack/service-ai@9.9.1':
+    resolution: {integrity: sha512-qTkKfMSmR2Hm2LPP8boCjScI2wo4h3gWcMgpWSpfbVnD96owirRLqJWrnlMk8i6SfPUaxUa7YxtxGuxGXQW1Cw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@ai-sdk/anthropic': ^3.0.0
@@ -940,54 +944,54 @@ packages:
       '@ai-sdk/openai':
         optional: true
 
-  '@objectstack/service-analytics@9.8.0':
-    resolution: {integrity: sha512-TVWPB4dYHtqw6E+R2L9Kxgqgoxk1XXQKDqS3sR7jiqlPkWjYj9MCuZQ1Q/dWzWiit8JH8GZ+7geCXXbIneV2Tw==}
+  '@objectstack/service-analytics@9.9.1':
+    resolution: {integrity: sha512-K9/rLVlWqGkgrjni1L13ONYZ5uK1n76Eymtp7r6hHbHfzmtJOhMBWmAHpUAH5vO/166xnZAaWPE4gi+CPSr6tw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-automation@9.8.0':
-    resolution: {integrity: sha512-BNVmsrvsC4/LEMrTD+6BgzAm3+wMAlvC9wrB5NKr8c0jIiFrMZtwM85Y9mhaa8I/fvaAyT0uN0yWBc2mQqUAUQ==}
+  '@objectstack/service-automation@9.9.1':
+    resolution: {integrity: sha512-Yb7D/ealu9ktll1ODz9Hcj7pDjK1URq8oUQUXzJkwQVfVaIHEeb2JYjpKeBh14ex4gxcy6oU4BbVB7yfcLfp+w==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-cache@9.8.0':
-    resolution: {integrity: sha512-U9/kMg/7BUPylREgZIKoWIgEsoPXtFktIDTzwVCb2veEo5MyYOjA1RF82pM2qXBUppxcfmmW/6W7cYbC/vH+PA==}
+  '@objectstack/service-cache@9.9.1':
+    resolution: {integrity: sha512-DgWaHx0u1NlcYvdqX82JBhzQiZCfMcMBxrD1Ieo5XbBEk/UZMFYp/oV2snb1zMFw90yDA64cLvhkagqBBmajIA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-cluster@9.8.0':
-    resolution: {integrity: sha512-3c8LEEyo/MisntCT0X3BHrkgFez8fRXEAwFUSp33gykmauodo6R45xoGNKF6ziwCrMGljLF8DQx4PmOccboZRQ==}
+  '@objectstack/service-cluster@9.9.1':
+    resolution: {integrity: sha512-chtcJaqJj5mhDEIaEqU0yF1QSceeOTe9eJrh0u00N6zueKhy5KTbLKu3MvrfHavjkPeGDScVs/uEdKuzsE6eFg==}
 
-  '@objectstack/service-datasource@9.8.0':
-    resolution: {integrity: sha512-ksveHLCseCi4xhHBlbQzQjKlbw2MlOdoi8NDYg3nD06+U6f77wQMrOfJmOAmvQICk2a3uGMNwaSAnbpBGXK8RA==}
+  '@objectstack/service-datasource@9.9.1':
+    resolution: {integrity: sha512-xtc/csffRY3YZ4waXpNZRfGTSs1emEVNLwwTyZ7zcWUyiCThyst09ZPKQZcMo/miE8c2TxN6TQnPn6WJ2ayCGw==}
 
-  '@objectstack/service-i18n@9.8.0':
-    resolution: {integrity: sha512-WyUvm4CSy/UJZtddGoYhnc5pXzP73el+NhAOF2GuTPwxtndLBZNWg1+jEwd0xYGijwo9mCqgCCGD6ThYWudTgA==}
+  '@objectstack/service-i18n@9.9.1':
+    resolution: {integrity: sha512-rwg1avx6QT3fshKRkJSi0K68VP/nXW5cuViIhoHVr57n/RpzfFbMzlw4nbk7bhFQ1UnsOTzr03Tck82JZ7SoUQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-job@9.8.0':
-    resolution: {integrity: sha512-1F6KdwiN90v+S1sGbTxjbVhqr7XuuSBqwEhn3L8KUg0QouvoWM9xByJuxii8yrWmtrHqbIbszOqpVLQmS5PBbg==}
+  '@objectstack/service-job@9.9.1':
+    resolution: {integrity: sha512-rGVKWGroQ91uoFSy4KPi5+/5JD1ZeGYJ2guVzgPHZ9C+IY/mmobl6Oj895RHwxtzwBOmEME3un0a14H2zJm8CQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-messaging@9.8.0':
-    resolution: {integrity: sha512-0WV2ab+ISAqtr7jsnLMA0DNE9ZSE6CRASldNwQHrs1ivs4YG32uIjKYa/AzBtNlLrze5TNKHBor5DeWOkk8xEw==}
+  '@objectstack/service-messaging@9.9.1':
+    resolution: {integrity: sha512-peCrnGeu/Dix06feDhP+ZiuFFn/yb7Z7iQxQIZ3xYbPShy8bvo+QlHR9O8P7Yrzk6siui2XkTBBLhHkWULaFFw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-package@9.8.0':
-    resolution: {integrity: sha512-2JcGqrDfJd6U5L1Zk7qS3SzaJDIkf0JxqD4kRPquwBHDZxfjqtpexZStGlYab6MlMHkbifXpJyEV1KHAGFQ2Kg==}
+  '@objectstack/service-package@9.9.1':
+    resolution: {integrity: sha512-pZzkFgPnrWVeIW7S4vZeJLZ16cQhNp//8ddUaRdrkYfdfE0afiSb209whP2Cx5F6uJPIG3PoGHerg+lBp2HEGQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-queue@9.8.0':
-    resolution: {integrity: sha512-bMul7Zeh3oGKXjZcw5gMwgUWCtvQsvPQIa040N3eBa1D8nQmj78FSgY+ZyiijKnONfzYvZI0eMsz+MmA51EPOw==}
+  '@objectstack/service-queue@9.9.1':
+    resolution: {integrity: sha512-ING2s8NG52nPOcLtp8BkIqDb2CEZ5AFPPWObSCu9jTXGr32Ji6wuIybGesI1gsI+XIHSiDSUrZ6Tidlyd6Pqjg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-realtime@9.8.0':
-    resolution: {integrity: sha512-eNA+LgHpkOPsAgjbfyQDkhTXw/lWOE1I+NXCmQgfEKXkB7oGXnhO82/TQDJVu8uetIeboxAtp3n8Qgdx+MR/1g==}
+  '@objectstack/service-realtime@9.9.1':
+    resolution: {integrity: sha512-CFeaysvvrAtqNhIlgVqIHoT3RzBWYfxd8fgNOzYTH2yWWkHNTKjSE7bCwWO+RebQwLbe1B+aGylzEFy9ubMfpA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-settings@9.8.0':
-    resolution: {integrity: sha512-pYR1bUvr1TOM0gZQcUdEkazgBraLygKnQX/89fpHzWREIvYPpAXZViT7WFpSriq+BKa6kS7WKrDryGFR4G63yA==}
+  '@objectstack/service-settings@9.9.1':
+    resolution: {integrity: sha512-YzIi3kfPr/y22eSIWw/ArPdEeXaTF5FnyhHrPuUnrvzgHtWkvVZFqtZJFfBlhHzHinX2OKznAwwkKzLUeqxbGQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-storage@9.8.0':
-    resolution: {integrity: sha512-q3tv/qi6haw/HtjYYMo46dY7jcU5swI0+WZIJ5DE6Obruz6EOQFErV27/xn15pujm9v+arcS39W7I9BME0JmPA==}
+  '@objectstack/service-storage@9.9.1':
+    resolution: {integrity: sha512-24yU9R/m+7EP5/tWN2TS2AVsLhItSDyUxzfXeUTn8WT4hHoh3PVQXmIW2MYoaByv0fhWjN60VX115sHuAMYJnw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@aws-sdk/client-s3': ^3.0.0
@@ -998,12 +1002,12 @@ packages:
       '@aws-sdk/s3-request-presigner':
         optional: true
 
-  '@objectstack/setup@9.8.0':
-    resolution: {integrity: sha512-KZwMwm8PyL0p8q5jf1i0Wv54suJaNFjMzMTGvYB4D0uvOZuCiP2xgqq5Rj5AE8hqe5eYphyLWv9oTGwT5OWNKw==}
+  '@objectstack/setup@9.9.1':
+    resolution: {integrity: sha512-CReL+AbVXAwiyQ6D82BNoPT06BIVFJetSu4FwfmVZpIgClXGbhmkr2po5E7uJVioJ9dteIwAtnKTyHQEwJ42fw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/spec@9.8.0':
-    resolution: {integrity: sha512-6reVmFCFkHp9ub2yyRLHYut9kniKbt+1SVuxzBvPvrSMBKxGO2qPCnb9IcywlHchrBbl2wyTY2cj9+5/aVSkSQ==}
+  '@objectstack/spec@9.9.1':
+    resolution: {integrity: sha512-uz0IM0Go1WMKcEyxPHHlxzmHK9dEay13UBTbEnuka0OBOvh2KFq77WQ4w+UX6Nq1N9fLEL3qcdTkW4WlO8ocVw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       ai: ^6.0.0
@@ -1011,23 +1015,23 @@ packages:
       ai:
         optional: true
 
-  '@objectstack/studio@9.8.0':
-    resolution: {integrity: sha512-aCX05FsnJNFbPvjr4rb7f3tqg2JwD3pxd2eC8IA2zR2v/HEKAGciAr+WjqbDTrhiUoNwG6hUqXC83LrCUga6FQ==}
+  '@objectstack/studio@9.9.1':
+    resolution: {integrity: sha512-rN5O0JVueFIDyjuoVSnifp/a76pmUZamxk7Nb4d6c7pWX0oLvqr6hVq714L0sgJeVuKmF5UHCI0HvcSS6IbQ4g==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/trigger-api@9.8.0':
-    resolution: {integrity: sha512-oY0mJKJC2cJOhDS6HI9v+6quCAsMe8B/UojBGckQndFRb/Zcw8UgWYNr6tp/pKlR7ii7ySaARigS3yZ3GHQv+g==}
+  '@objectstack/trigger-api@9.9.1':
+    resolution: {integrity: sha512-L9k8bumHaSb3lOCocD4vGRwel1r1N4Q5/MG41NZwjcd8Y0ZfiPHAUzkDN/9JtC+1ritWS9XlwG7/tn2l1no/Rw==}
 
-  '@objectstack/trigger-record-change@9.8.0':
-    resolution: {integrity: sha512-As1Fek+cZWh+gBmEDCwRNlLkvjsnQcpZf1DUsKaR4n1WO+9cP/Q3GsM3wqj8PT3iSVX/WIJ6f+PxA/5AA57i6A==}
+  '@objectstack/trigger-record-change@9.9.1':
+    resolution: {integrity: sha512-ruZPitPt6r46sQvEDxuDbPv3rPzVUpUj3KEV2vRv85CmSkp301zVV0+EZBDT88ApHMRAX4V9j0wDgFvTRGX7Nw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/trigger-schedule@9.8.0':
-    resolution: {integrity: sha512-+uFvaU8S3IgII6tPevW2MNXIxu1eaUdDd2tjAhwm2ouLnfZNCCh+F0eZ2Zr2WBfkY77ci2V9m+J2suwuo59TQg==}
+  '@objectstack/trigger-schedule@9.9.1':
+    resolution: {integrity: sha512-Bc7g7gT1zGKhjXq0+e07MZo0B+wabYtquRMKKH24iL5hKDN1TcviY7HJ66tGawq3GoFs5PtXEi81Km6lxedcOQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/types@9.8.0':
-    resolution: {integrity: sha512-ZoZNSEfPeaATRu4n4AFUyE5i2t5hpIeU2oJ+xT8lK/NK17dc6OdkgXO1BzpzWkSdMgw4j03vi8j90QqF0hAJaw==}
+  '@objectstack/types@9.9.1':
+    resolution: {integrity: sha512-YHiWbN7HjaNGi8Cx6N3rOmLM0x75MbHEgVHgcYDGdv8ouFijhVCo4I9EpYF+XYzI1kBOYrmdEcBmBDmkVW9uNA==}
     engines: {node: '>=18.0.0'}
 
   '@oclif/core@4.11.4':
@@ -2310,64 +2314,65 @@ snapshots:
 
   '@noble/hashes@2.2.0': {}
 
-  '@objectstack/account@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/account@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/cli@9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@objectstack/cli@9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@ai-sdk/anthropic': 3.0.84(zod@4.4.3)
       '@ai-sdk/gateway': 3.0.131(zod@4.4.3)
       '@ai-sdk/google': 3.0.82(zod@4.4.3)
       '@ai-sdk/openai': 3.0.71(zod@4.4.3)
-      '@objectstack/account': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/client': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/console': 9.8.0
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/driver-memory': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/driver-mongodb': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/driver-sql': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/driver-sqlite-wasm': 9.8.0(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
-      '@objectstack/formula': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/mcp': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/objectql': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/observability': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/plugin-approvals': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/plugin-audit': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/plugin-auth': 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@objectstack/plugin-email': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/plugin-hono-server': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/plugin-org-scoping': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/plugin-reports': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/plugin-security': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/plugin-sharing': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/plugin-webhooks': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/rest': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/runtime': 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@objectstack/service-ai': 9.8.0(@ai-sdk/anthropic@3.0.84(zod@4.4.3))(@ai-sdk/gateway@3.0.131(zod@4.4.3))(@ai-sdk/google@3.0.82(zod@4.4.3))(@ai-sdk/openai@3.0.71(zod@4.4.3))
-      '@objectstack/service-analytics': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-automation': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-cache': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-datasource': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-job': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-messaging': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-package': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-queue': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-realtime': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-settings': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-storage': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/setup': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/studio': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/trigger-api': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/trigger-record-change': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/trigger-schedule': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/types': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/account': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/client': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/cloud-connection': 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/console': 9.9.1
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/driver-memory': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/driver-mongodb': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/driver-sql': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/driver-sqlite-wasm': 9.9.1(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
+      '@objectstack/formula': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/mcp': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/objectql': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/observability': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/plugin-approvals': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/plugin-audit': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/plugin-auth': 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/plugin-email': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/plugin-hono-server': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/plugin-org-scoping': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/plugin-reports': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/plugin-security': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/plugin-sharing': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/plugin-webhooks': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/rest': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/runtime': 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/service-ai': 9.9.1(@ai-sdk/anthropic@3.0.84(zod@4.4.3))(@ai-sdk/gateway@3.0.131(zod@4.4.3))(@ai-sdk/google@3.0.82(zod@4.4.3))(@ai-sdk/openai@3.0.71(zod@4.4.3))
+      '@objectstack/service-analytics': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-automation': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-cache': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-datasource': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-job': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-messaging': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-package': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-queue': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-realtime': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-settings': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-storage': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/setup': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/studio': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/trigger-api': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/trigger-record-change': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/trigger-schedule': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/types': 9.9.1(ai@6.0.205(zod@4.4.3))
       '@oclif/core': 4.11.4
       bundle-require: 5.1.0(esbuild@0.28.1)
       chalk: 5.6.2
@@ -2424,34 +2429,83 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/client@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/client@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/console@9.8.0': {}
-
-  '@objectstack/core@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/cloud-connection@9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/runtime': 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/types': 9.9.1(ai@6.0.205(zod@4.4.3))
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@better-auth/utils'
+      - '@better-fetch/fetch'
+      - '@cloudflare/workers-types'
+      - '@lynx-js/react'
+      - '@mongodb-js/zstd'
+      - '@opentelemetry/api'
+      - '@prisma/client'
+      - '@sveltejs/kit'
+      - '@tanstack/react-start'
+      - '@tanstack/solid-start'
+      - ai
+      - better-call
+      - better-sqlite3
+      - drizzle-kit
+      - drizzle-orm
+      - gcp-metadata
+      - jose
+      - kerberos
+      - kysely
+      - mongodb
+      - mongodb-client-encryption
+      - mysql
+      - mysql2
+      - nanostores
+      - next
+      - pg
+      - pg-native
+      - pg-query-stream
+      - prisma
+      - react
+      - react-dom
+      - snappy
+      - socks
+      - solid-js
+      - sqlite3
+      - supports-color
+      - svelte
+      - tedious
+      - vitest
+      - vue
+
+  '@objectstack/console@9.9.1': {}
+
+  '@objectstack/core@9.9.1(ai@6.0.205(zod@4.4.3))':
+    dependencies:
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-memory@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/driver-memory@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
       mingo: 7.2.1
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-mongodb@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/driver-mongodb@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
       mongodb: 7.3.0
       nanoid: 5.1.11
     transitivePeerDependencies:
@@ -2464,10 +2518,10 @@ snapshots:
       - snappy
       - socks
 
-  '@objectstack/driver-sql@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/driver-sql@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
       knex: 3.2.10(better-sqlite3@12.10.1)
       nanoid: 5.1.11
     optionalDependencies:
@@ -2479,11 +2533,11 @@ snapshots:
       - pg-query-stream
       - supports-color
 
-  '@objectstack/driver-sqlite-wasm@9.8.0(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)':
+  '@objectstack/driver-sqlite-wasm@9.9.1(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/driver-sql': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/driver-sql': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
       knex: 3.2.10(better-sqlite3@12.10.0)
       nanoid: 5.1.11
       sql.js: 1.14.1
@@ -2499,48 +2553,48 @@ snapshots:
       - supports-color
       - tedious
 
-  '@objectstack/formula@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/formula@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
       '@marcbachmann/cel-js': 7.6.1
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/mcp@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/mcp@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/types': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/types': 9.9.1(ai@6.0.205(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - ai
       - supports-color
 
-  '@objectstack/metadata-core@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/metadata-core@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/metadata-fs@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/metadata-fs@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/metadata-core': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/metadata-core': 9.9.1(ai@6.0.205(zod@4.4.3))
       chokidar: 5.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/metadata@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/metadata@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/metadata-core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/metadata-fs': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/types': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/metadata-core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/metadata-fs': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/types': 9.9.1(ai@6.0.205(zod@4.4.3))
       chokidar: 5.0.0
       glob: 13.0.6
       js-yaml: 4.2.0
@@ -2549,62 +2603,62 @@ snapshots:
       - ai
       - vitest
 
-  '@objectstack/objectql@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/objectql@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/formula': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/metadata-core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/types': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/formula': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/metadata-core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/types': 9.9.1(ai@6.0.205(zod@4.4.3))
       ajv: 8.20.0
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/observability@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/observability@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/platform-objects@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/platform-objects@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/metadata-core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
-    transitivePeerDependencies:
-      - ai
-      - vitest
-
-  '@objectstack/plugin-approvals@9.8.0(ai@6.0.205(zod@4.4.3))':
-    dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/formula': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/metadata-core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/metadata-core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-audit@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/plugin-approvals@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/formula': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/metadata-core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-auth@9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@objectstack/plugin-audit@9.9.1(ai@6.0.205(zod@4.4.3))':
+    dependencies:
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
+    transitivePeerDependencies:
+      - ai
+      - vitest
+
+  '@objectstack/plugin-auth@9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/oauth-provider': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-auth@1.6.18(@opentelemetry/api@1.9.1)(better-sqlite3@12.10.0)(mongodb@7.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(better-call@1.3.6(zod@4.4.3))
       '@noble/hashes': 2.2.0
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/types': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/types': 9.9.1(ai@6.0.205(zod@4.4.3))
       better-auth: 1.6.18(@opentelemetry/api@1.9.1)(better-sqlite3@12.10.0)(mongodb@7.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@better-auth/utils'
@@ -2636,101 +2690,103 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/plugin-email@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/plugin-email@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/formula': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-hono-server@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/plugin-hono-server@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
       '@hono/node-server': 2.0.4(hono@4.12.25)
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/types': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/types': 9.9.1(ai@6.0.205(zod@4.4.3))
       hono: 4.12.25
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-org-scoping@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/plugin-org-scoping@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-reports@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/plugin-reports@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
+      croner: 10.0.1
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-security@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/plugin-security@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-sharing@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/plugin-sharing@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/objectql': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/objectql': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-webhooks@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/plugin-webhooks@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-messaging': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-messaging': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/rest@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/rest@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-package': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-package': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/runtime@9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@objectstack/runtime@9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/driver-memory': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/driver-sql': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/driver-sqlite-wasm': 9.8.0(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
-      '@objectstack/formula': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/metadata': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/objectql': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/observability': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/plugin-auth': 9.8.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@objectstack/plugin-org-scoping': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/plugin-security': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/rest': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-cluster': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/service-i18n': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/types': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/driver-memory': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/driver-sql': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/driver-sqlite-wasm': 9.9.1(ai@6.0.205(zod@4.4.3))(better-sqlite3@12.10.0)
+      '@objectstack/formula': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/metadata': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/objectql': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/observability': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/plugin-auth': 9.9.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(ai@6.0.205(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.3.0)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/plugin-org-scoping': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/plugin-security': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/rest': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-cluster': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/service-i18n': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/types': 9.9.1(ai@6.0.205(zod@4.4.3))
       quickjs-emscripten: 0.32.0
       zod: 4.4.3
     optionalDependencies:
-      '@objectstack/driver-mongodb': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/driver-mongodb': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@better-auth/utils'
@@ -2774,13 +2830,13 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/service-ai@9.8.0(@ai-sdk/anthropic@3.0.84(zod@4.4.3))(@ai-sdk/gateway@3.0.131(zod@4.4.3))(@ai-sdk/google@3.0.82(zod@4.4.3))(@ai-sdk/openai@3.0.71(zod@4.4.3))':
+  '@objectstack/service-ai@9.9.1(@ai-sdk/anthropic@3.0.84(zod@4.4.3))(@ai-sdk/gateway@3.0.131(zod@4.4.3))(@ai-sdk/google@3.0.82(zod@4.4.3))(@ai-sdk/openai@3.0.71(zod@4.4.3))':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/formula': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/types': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/formula': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/types': 9.9.1(ai@6.0.205(zod@4.4.3))
       ai: 6.0.205(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -2789,159 +2845,159 @@ snapshots:
       '@ai-sdk/google': 3.0.82(zod@4.4.3)
       '@ai-sdk/openai': 3.0.71(zod@4.4.3)
 
-  '@objectstack/service-analytics@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/service-analytics@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-automation@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/service-automation@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/formula': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/formula': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cache@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/service-cache@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/observability': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/observability': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cluster@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/service-cluster@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-datasource@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/service-datasource@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-i18n@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/service-i18n@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-job@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/service-job@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
       croner: 10.0.1
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-messaging@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/service-messaging@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-package@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/service-package@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-queue@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/service-queue@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
-    transitivePeerDependencies:
-      - ai
-      - vitest
-
-  '@objectstack/service-realtime@9.8.0(ai@6.0.205(zod@4.4.3))':
-    dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-settings@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/service-realtime@9.9.1(ai@6.0.205(zod@4.4.3))':
+    dependencies:
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
+    transitivePeerDependencies:
+      - ai
+      - vitest
+
+  '@objectstack/service-settings@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
       '@noble/ciphers': 2.2.0
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/types': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/types': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-storage@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/service-storage@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/observability': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/observability': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/setup@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/setup@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/spec@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/spec@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
       zod: 4.4.3
     optionalDependencies:
       ai: 6.0.205(zod@4.4.3)
 
-  '@objectstack/studio@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/studio@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/platform-objects': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/platform-objects': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/trigger-api@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/trigger-api@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/trigger-record-change@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/trigger-record-change@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/trigger-schedule@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/trigger-schedule@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 9.8.0(ai@6.0.205(zod@4.4.3))
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/core': 9.9.1(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/types@9.8.0(ai@6.0.205(zod@4.4.3))':
+  '@objectstack/types@9.9.1(ai@6.0.205(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 9.8.0(ai@6.0.205(zod@4.4.3))
+      '@objectstack/spec': 9.9.1(ai@6.0.205(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -113,6 +113,7 @@ minimumReleaseAgeExclude:
   - '@objectstack/trigger-schedule@9.8.0'
   - '@objectstack/types'
   - '@objectstack/types@9.7.0'
+  - '@objectstack/cloud-connection@9.9.1'
 # pnpm 10 no longer reads `pnpm.onlyBuiltDependencies` from package.json — it
 # must live here. These deps have native/postinstall build steps.
 onlyBuiltDependencies:


### PR DESCRIPTION
## What

Upgrade all `@objectstack/*` dependencies from `^9.8.0` → **`^9.9.1`** across every template and the `all` composition workspace.

## Verification (build passing ≠ it works — booted it)

- ✅ `pnpm typecheck`, `pnpm build`, `pnpm format:check`, `pnpm -r test` all pass
- ✅ Composed the marketplace (`@objectlab/all`): **9 apps · 41 objects · 30 flows**
- ✅ Booted the `all` env on a fresh DB → `Server is ready` + `seeded on empty DB`, **zero `sys_*` errors** on a clean single-instance start
- ✅ Browser-verified **all 9 apps** as the seeded admin (`admin@objectos.ai`): dashboards, list views, status grouping, lookups, and rollups all render against seed data

## Notes / follow-ups (not blocking, left out of this PR)

1. **New `liveness-dead-property` lint (9.9.x):** ~112 warnings across all templates for no-op object flags `enable.trackHistory` / `enable.files` / `enable.feeds` / `enable.activities`. Per-field `Field.trackHistory` and the `sys_*` objects are the live mechanisms. Worth a focused cleanup PR.
2. **Seed-data validation failures:** 4 `compliance_assessment` + 2 `content_piece` + 2 `content_cta` seed records are rejected at boot (`rule_violation` / `piece required`). This leaves the compliance "Assessments Completed by Month" chart empty.
3. **Dashboard polish (cross-template):** KPI cards render the raw field alias (`control_count`, `sum_total_value`, `task_count`) as the unit label, and chart titles stay in English under zh-CN dashboards.
4. **Todo default landing is empty:** seed `todo_task` rows have no assignee, so the default "My Work" dashboard shows 0/0/0 for the admin even though 16 tasks exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)