### PR TITLE
fix(dashboards): use date for charted time fields so time-series render

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,19 @@ and confirm `Server is ready` + `seeded on empty DB` + zero `ERROR` log lines.
   is *omitted entirely* from the payload (they do on update / explicit null).
   A field with a `defaultValue` is always present, so its rules fire on insert.
   (Platform: framework#1871.)
+- **Dashboard time-series on a `datetime` field render empty.** The analytics
+  dataset executor binds dashboard date tokens (`{12_months_ago}`, `{today}`,
+  `{N_weeks_ago}`, …) as **ISO date strings** (`"2025-06-18"`). A `Field.date`
+  column stores ISO text, so `col >= '2025-06-18'` matches; a `Field.datetime`
+  column stores an **integer epoch** (e.g. `1780012800000`), and in SQLite an
+  INTEGER always sorts *before* any TEXT, so `epoch >= 'YYYY-MM-DD'` is **always
+  false** → the chart/KPI silently shows "No rows" even though the data exists
+  and the un-filtered cube returns it. Use **`Field.date`** for any field a
+  dashboard filters or groups by a date token (chart x-axes, "last N months"
+  filters). Keep `datetime` only where sub-day precision is load-bearing (e.g.
+  `helpdesk_ticket.resolved_at`, used by SLA-resolution timing) — those charts
+  stay empty until the platform binds epoch for datetime columns. (Platform:
+  framework — analytics date-token vs datetime-column type mismatch.)
 
 ## Running the `all` env locally (for runtime/UI testing)
 

--- a/packages/compliance/src/objects/compliance_assessment.object.ts
+++ b/packages/compliance/src/objects/compliance_assessment.object.ts
@@ -29,7 +29,11 @@ export const Assessment = ObjectSchema.create({
       maxLength: 40,
       description: 'e.g. "2026-Q1" — groups assessments for reporting.',
     }),
-    assessed_at: Field.datetime({
+    // `date` (not `datetime`): assessments are reported at day granularity, and
+    // dashboard time-series filters (`assessed_at >= {N_months_ago}`) only match
+    // when the column stores an ISO date string — a `datetime` epoch column never
+    // matches the analytics layer's ISO-string date tokens in SQLite. See AGENTS.md.
+    assessed_at: Field.date({
       label: 'Assessed At',
     }),
     assessor: Field.lookup('sys_user', { label: 'Assessor' }),

--- a/packages/content/src/objects/content_piece.object.ts
+++ b/packages/content/src/objects/content_piece.object.ts
@@ -157,7 +157,9 @@ export const Piece = ObjectSchema.create({
     // Lifecycle stamps
     submitted_at: Field.datetime({ label: 'Submitted At', readonly: true, group: 'planning' }),
     approved_at: Field.datetime({ label: 'Approved At', readonly: true, group: 'planning' }),
-    published_at: Field.datetime({ label: 'Published At', readonly: true, group: 'planning' }),
+    // `date` (not `datetime`): the published-by-month chart filters `published_at
+    // >= {12_months_ago}`, which only matches an ISO-date-string column. See AGENTS.md.
+    published_at: Field.date({ label: 'Published At', readonly: true, group: 'planning' }),
     archived_at: Field.datetime({ label: 'Archived At', readonly: true, group: 'planning' }),
 
     // Denormalised performance rollups — native roll-up summaries (#1870),

--- a/packages/content/src/objects/content_publication.object.ts
+++ b/packages/content/src/objects/content_publication.object.ts
@@ -44,7 +44,10 @@ export const Publication = ObjectSchema.create({
       group: 'core',
       description: 'Where the live thing lives. The CMS integration seam.',
     }),
-    published_at: Field.datetime({
+    // `date` (not `datetime`): the ROI dashboard filters `published_at >=
+    // {90_days_ago}`, which only matches an ISO-date-string column — a datetime
+    // epoch column never matches the analytics ISO-string date tokens. See AGENTS.md.
+    published_at: Field.date({
       label: 'Published At',
       required: true,
       group: 'core',

--- a/packages/expense/src/objects/expense_report.object.ts
+++ b/packages/expense/src/objects/expense_report.object.ts
@@ -101,7 +101,9 @@ export const ExpenseReport = ObjectSchema.create({
     }),
     approved_at: Field.datetime({ label: 'Approved At', group: 'financial' }),
 
-    reimbursed_at: Field.datetime({ label: 'Reimbursed At', group: 'reimbursement' }),
+    // `date` (not `datetime`): the spend-by-month chart filters `reimbursed_at >=
+    // {12_months_ago}`, which only matches an ISO-date-string column. See AGENTS.md.
+    reimbursed_at: Field.date({ label: 'Reimbursed At', group: 'reimbursement' }),
     payment_method: Field.select({
       label: 'Payment Method',
       group: 'reimbursement',

--- a/packages/todo/src/objects/todo_task.object.ts
+++ b/packages/todo/src/objects/todo_task.object.ts
@@ -76,7 +76,10 @@ export const Task = ObjectSchema.create({
     // Planning
     due_date: Field.date({ label: 'Due Date', group: 'planning' }),
     started_at: Field.datetime({ label: 'Started At', readonly: true, group: 'planning' }),
-    completed_at: Field.datetime({ label: 'Completed At', readonly: true, group: 'planning' }),
+    // `date` (not `datetime`): the throughput chart filters `completed_at >=
+    // {12_weeks_ago}`, which only matches an ISO-date-string column — a datetime
+    // epoch column never matches the analytics ISO-string date tokens. See AGENTS.md.
+    completed_at: Field.date({ label: 'Completed At', readonly: true, group: 'planning' }),
     estimate_hours: Field.number({
       label: 'Estimate (hours)',
       scale: 2,


### PR DESCRIPTION
Several dashboards' time-series charts and "last N months/days" KPIs silently rendered **"No rows"** even though the data existed.

## Root cause (platform-level)
The analytics dataset executor binds dashboard date tokens (`{12_months_ago}`, `{90_days_ago}`, `{today}`, …) as ISO date **strings** (`"2025-06-18"`).

- A `Field.date` column stores ISO **text** → `col >= '2025-06-18'` matches. ✅
- A `Field.datetime` column stores an **integer epoch** (`1780012800000`). In SQLite an INTEGER always sorts *before* any TEXT, so `epoch >= 'YYYY-MM-DD'` is **always false** → empty result. ❌

The un-filtered cube returns the rows (which is why the data looked present). Confirmed by diffing the **working** evidence KPI (`expires_on` = `date` → text storage) against the **broken** assessments chart (`assessed_at` = `datetime` → epoch storage), and by direct SQLite queries:

```
WHERE assessed_at >= '2025-06-18'   → 0 rows   (datetime/epoch column)
WHERE expires_on  >= '2026-06-18'   → 2 rows   (date/text column)
```

## Template fix
Change the charted / date-token-filtered timestamp fields from `datetime` → `date` (day granularity is all these reports need; the column then stores ISO text the analytics layer compares correctly):

| field | chart |
|---|---|
| `compliance_assessment.assessed_at` | Assessments by Month |
| `todo_task.completed_at` | Throughput by Week |
| `expense_report.reimbursed_at` | Spend by Month |
| `content_piece.published_at` | Published by Month |
| `content_publication.published_at` | ROI dashboard (90-day KPIs + charts) |

**Deliberately not changed:** `helpdesk_ticket.resolved_at` stays `datetime` — SLA-resolution timing needs sub-day precision (flows compare it, breach logic uses it). Its "Resolutions by Day" chart stays empty until the platform binds epoch for datetime columns. The full gotcha is documented in `AGENTS.md` for future template authors.

## Verification
- Fresh boot stores all five fields as ISO text (`typeof = text`).
- Chart SQL (`status IN (...) AND assessed_at >= '2025-06-18'`) goes **0 → 4** rows.
- Browser: the compliance **"按月完成的评估（近 12 个月）"** chart now renders a line (y-axis populated) where it previously showed **"No rows"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)