### PR TITLE
fix(templates): replace invalid `category: "starter"` with valid domain categories

### DIFF
--- a/packages/compliance/objectstack.manifest.json
+++ b/packages/compliance/objectstack.manifest.json
@@ -6,7 +6,7 @@
   "displayName": "Compliance",
   "description": "Compliance posture & evidence management: control library, evidence requests, audit findings, and remediation workflows on ObjectStack.",
   "tagline": "Controls, evidence, findings — your audit-ready starter.",
-  "category": "starter",
+  "category": "operations",
   "isStarter": true,
   "publisher": "objectstack",
   "license": "Apache-2.0",

--- a/packages/content/objectstack.manifest.json
+++ b/packages/content/objectstack.manifest.json
@@ -6,7 +6,7 @@
   "displayName": "Content",
   "description": "Content marketing engine: pipeline → publish → measure. Editorial calendar, competitive signal capture, channel ROI rollups, and an 8-state piece workflow with approval gates.",
   "tagline": "Pipeline, publish, measure — content marketing on rails.",
-  "category": "starter",
+  "category": "marketing",
   "isStarter": true,
   "publisher": "objectstack",
   "license": "Apache-2.0",

--- a/packages/contracts/objectstack.manifest.json
+++ b/packages/contracts/objectstack.manifest.json
@@ -6,7 +6,7 @@
   "displayName": "Contracts",
   "description": "Post-signature contract lifecycle: AI-extracted metadata, multi-step approvals, obligation tracking, and renewal alerts. Bring your own Word + DocuSign.",
   "tagline": "Post-signature CLM with AI extraction.",
-  "category": "starter",
+  "category": "operations",
   "isStarter": true,
   "publisher": "objectstack",
   "license": "Apache-2.0",

--- a/packages/expense/objectstack.manifest.json
+++ b/packages/expense/objectstack.manifest.json
@@ -6,7 +6,7 @@
   "displayName": "Expense",
   "description": "Employee expense & reimbursement: multi-line expense reports, category policy, amount-tiered approvals, and reimbursement tracking on ObjectStack.",
   "tagline": "Report-first expense: claim \u2192 approve \u2192 reimburse.",
-  "category": "starter",
+  "category": "finance",
   "isStarter": true,
   "publisher": "objectstack",
   "license": "Apache-2.0",

--- a/packages/helpdesk/objectstack.manifest.json
+++ b/packages/helpdesk/objectstack.manifest.json
@@ -5,7 +5,7 @@
   "manifestId": "app.objectstack.template.helpdesk",
   "displayName": "AI Helpdesk",
   "description": "AI-first customer support: native AI triage, suggested replies, KB recall, sentiment-driven escalation, customer portal via permissions.",
-  "category": "starter",
+  "category": "operations",
   "isStarter": true,
   "publisher": "objectstack",
   "license": "Apache-2.0",

--- a/packages/hr/objectstack.manifest.json
+++ b/packages/hr/objectstack.manifest.json
@@ -6,7 +6,7 @@
   "displayName": "Human Resources",
   "description": "People directory, time-off approvals, and document expiry tracking on ObjectStack.",
   "tagline": "Directory, time-off, document expiry — your starter HRIS.",
-  "category": "starter",
+  "category": "hr",
   "isStarter": true,
   "publisher": "objectstack",
   "license": "Apache-2.0",

--- a/packages/procurement/objectstack.manifest.json
+++ b/packages/procurement/objectstack.manifest.json
@@ -6,7 +6,7 @@
   "displayName": "Procurement",
   "description": "Source-to-pay procurement: vendors, requisitions, purchase orders, receipts, and invoice matching on ObjectStack.",
   "tagline": "Source-to-pay: requisitions → POs → 3-way match.",
-  "category": "starter",
+  "category": "operations",
   "isStarter": true,
   "publisher": "objectstack",
   "license": "Apache-2.0",

--- a/packages/todo/objectstack.manifest.json
+++ b/packages/todo/objectstack.manifest.json
@@ -6,7 +6,7 @@
   "displayName": "Todo",
   "description": "Universal task & project management starter — projects, tasks, comments, approvals, and dashboards on ObjectStack.",
   "tagline": "Tasks, projects, approvals — the universal starter.",
-  "category": "starter",
+  "category": "productivity",
   "isStarter": true,
   "publisher": "objectstack",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Problem

The marketplace publish (staging run [27928155711](https://github.com/objectstack-ai/templates/actions/runs/27928155711), triggered by release `v0.1.0`) **failed**: 8 templates declared `category: "starter"`, which the control plane rejects:

```
✗ upsert failed (400): category must be one of:
  app, crm, sales, marketing, finance, hr, operations, project,
  productivity, data, devtools, utility, other
```

`"starter"` was never a valid domain category — starter-ness is already carried by the separate `isStarter: true` flag.

## Fix

| template | category |
|---|---|
| todo | `productivity` |
| content | `marketing` |
| expense | `finance` |
| hr | `hr` |
| procurement | `operations` |
| contracts | `operations` |
| helpdesk | `operations` |
| compliance | `operations` |

`project` was already `productivity` (valid) — untouched. One-line change per manifest; prettier-clean.

Unblocks publishing all 8 templates to staging/production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)