### PR TITLE
chore(release): bump helpdesk 0.1.3, project 0.1.2, hr 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: 
 ## [Unreleased]
 
 ### Changed
+- **Template catalog cleanup ([#76](https://github.com/objectstack-ai/templates/pull/76)).**
+  Unified display names — dropped the "AI" prefix (`AI Helpdesk` → `Helpdesk`,
+  `AI Project Management` → `Project Management`) across manifest, config, app
+  navigation, and translations so the catalog card and installed-app name agree;
+  reconciled the hr app name (`HR` → `Human Resources`). Converged marketplace
+  metadata to a single source (`objectstack.manifest.json` — removed the dead,
+  unread `objectstack.marketplace` block from every `package.json`, which still
+  carried the stale `category:"starter"`). Made AI copy honest: helpdesk triage
+  and project forecasting are scaffolds, not delivered models, with the AI
+  implementation tracked in `docs/ROADMAP.md`. Version bumps: helpdesk `0.1.3`,
+  project `0.1.2`, hr `0.1.2`.
 - **Upgraded all templates to `@objectstack/* ^10.2.0` (from `^10.0.0`).** Bumped
   every package's deps and the workspace `minimumReleaseAgeExclude` pins. 10.2 is a
   non-breaking minor — a full sweep of every `@objectstack/*@10.2.0` release found

--- a/packages/helpdesk/package.json
+++ b/packages/helpdesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectlab/helpdesk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "ObjectStack starter template: AI-first customer support helpdesk with native AI triage, suggested replies, and KB recall.",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/hr/package.json
+++ b/packages/hr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectlab/hr",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "ObjectStack starter template: employee directory, org chart, time-off, and document tracking",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectlab/project",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "description": "AI-powered project management template for ObjectStack",


### PR DESCRIPTION
Version bumps so the bundle changes from #76 publish to the marketplace.

- **helpdesk** `0.1.2 → 0.1.3` — config `manifest.name` + app nav label + translations changed.
- **project** `0.1.1 → 0.1.2` — config `manifest.name`, `pm_project` ai_* field group label, translations changed.
- **hr** `0.1.1 → 0.1.2` — config `manifest.name` (`HR` → `Human Resources`).

The other six templates are unchanged (only the unread `package.json` marketplace block was removed in #76) and will 409 no-op on republish. Catalog `display_name` / `description` for helpdesk & project update on publish regardless of version (sys_package upsert).

Adds the #76 CHANGELOG entry. After merge: cut Release `v0.1.1` → staging publish → auto-promote to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
